### PR TITLE
Implement redirect back to original page after login (#39)

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -30,9 +30,23 @@ module Authentication
   # Confirms a logged-in user (before_action filter)
   def require_login
     unless logged_in?
+      store_return_to_location
       flash[:alert] = "You must be logged in to access this page."
       redirect_to login_path
     end
+  end
+
+  # Store the URL the user was trying to access
+  def store_return_to_location
+    # Don't store login/logout paths to avoid redirect loops
+    return if request.path == login_path || request.path == logout_path
+
+    session[:return_to] = request.fullpath
+  end
+
+  # Redirect to stored location or default
+  def redirect_back_or_to(default)
+    redirect_to(session.delete(:return_to) || default)
   end
 
   # Confirms the correct user (for authorization)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < ApplicationController
     if user&.authenticate(params[:password])
       log_in(user)
       flash[:notice] = "Logged in successfully!"
-      redirect_to radio_models_path
+      redirect_back_or_to radio_models_path
     else
       flash.now[:alert] = "Invalid email or password"
       render :new, status: :unprocessable_entity

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -82,4 +82,39 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     get login_path
     assert_redirected_to radio_models_path
   end
+
+  test "should redirect to originally requested page after login" do
+    user = create(:user)
+
+    # Try to access a protected page
+    get edit_user_path(user)
+    assert_redirected_to login_path
+
+    # Log in
+    post login_path, params: {
+      email: user.email,
+      password: "password123"
+    }
+
+    # Should redirect back to the originally requested page
+    assert_redirected_to edit_user_path(user)
+    assert_equal "Logged in successfully!", flash[:notice]
+  end
+
+  test "should not redirect to login path after login" do
+    user = create(:user)
+
+    # Manually set return_to to login_path (simulating edge case)
+    get login_path
+    session[:return_to] = login_path
+
+    # Log in
+    post login_path, params: {
+      email: user.email,
+      password: "password123"
+    }
+
+    # Should redirect to default (radio_models_path), not login_path
+    assert_redirected_to radio_models_path
+  end
 end


### PR DESCRIPTION
## Summary
When users are redirected to the login page because they tried to access a protected page, the app now remembers where they were going and redirects them back after successful login.

## Problem Solved
Previously, users who tried to access a protected page (like editing their profile) would be redirected to login, but after logging in they'd be sent to the radio models index instead of their intended destination. This required manual navigation back to where they wanted to go.

## Implementation

### Authentication Concern Changes
Added three new methods to the Authentication concern:

**`store_return_to_location`**
- Stores the URL the user was trying to access in `session[:return_to]`
- Prevents storing login/logout paths to avoid redirect loops
- Called automatically by `require_login` before redirecting

**`redirect_back_or_to(default)`**
- Redirects to the stored URL (if exists) or the provided default
- Clears the stored URL from session after using it (one-time use)

**Updated `require_login`**
- Now calls `store_return_to_location` before redirecting to login
- Ensures the original destination is preserved

### SessionsController Changes
**Before:**
```ruby
redirect_to radio_models_path
```

**After:**
```ruby
redirect_back_or_to radio_models_path
```

Uses the new helper method to redirect to the stored location or default to radio models index.

### Edge Case Handling
- ✅ Prevents storing login/logout paths (would cause redirect loops)
- ✅ Clears stored path after using it (prevents stale redirects)
- ✅ Falls back to default if no stored path exists
- ✅ Works with full paths including query parameters

## User Experience

### Before This Change:
1. User clicks "Edit Profile" link
2. Not logged in → redirected to `/login`
3. User logs in successfully
4. Redirected to `/radio_models` (dashboard)
5. **User must manually navigate back to edit profile** ❌

### After This Change:
1. User clicks "Edit Profile" link
2. Not logged in → redirected to `/login`
3. User logs in successfully
4. **Automatically redirected to edit profile page** ✅
5. Seamless experience!

## Testing

### New Tests (2 added)

**Test 1: Redirect to originally requested page**
```ruby
test "should redirect to originally requested page after login" do
  user = create(:user)
  
  # Try to access a protected page
  get edit_user_path(user)
  assert_redirected_to login_path
  
  # Log in
  post login_path, params: { email: user.email, password: "password123" }
  
  # Should redirect back to the originally requested page
  assert_redirected_to edit_user_path(user)
  assert_equal "Logged in successfully!", flash[:notice]
end
```

**Test 2: Don't redirect to login path**
```ruby
test "should not redirect to login path after login" do
  user = create(:user)
  
  # Manually set return_to to login_path (simulating edge case)
  get login_path
  session[:return_to] = login_path
  
  # Log in
  post login_path, params: { email: user.email, password: "password123" }
  
  # Should redirect to default (radio_models_path), not login_path
  assert_redirected_to radio_models_path
end
```

### Test Results
✅ **80 tests passing** (78 existing + 2 new)
✅ **RuboCop clean** (44 files, 0 offenses)
✅ **Brakeman clean** (0 security warnings)

## Code Changes

### Files Modified
- `app/controllers/concerns/authentication.rb` - Added redirect-back logic
- `app/controllers/sessions_controller.rb` - Use new redirect helper
- `test/controllers/sessions_controller_test.rb` - Added 2 new tests

### Lines Changed
- **+50 lines** (new methods and tests)
- **-1 line** (replaced simple redirect)

## Acceptance Criteria
- ✅ `require_login` stores original URL in session before redirecting
- ✅ SessionsController redirects to stored URL after successful login
- ✅ Stored URL is cleared after redirect (one-time use)
- ✅ Login/logout paths are not stored (prevents loops)
- ✅ Tests verify redirect-back behavior
- ✅ All existing tests still pass

## References
- Issue #39
- Rails Session Guide: https://guides.rubyonrails.org/action_controller_overview.html#the-session

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>