### PR TITLE
Implement CodeplugLayout model (#7)

### DIFF
--- a/app/models/codeplug_layout.rb
+++ b/app/models/codeplug_layout.rb
@@ -1,0 +1,13 @@
+class CodeplugLayout < ApplicationRecord
+  # Associations
+  belongs_to :radio_model
+  belongs_to :user, optional: true
+
+  # Serialization
+  serialize :layout_definition, type: Hash, coder: JSON
+
+  # Validations
+  validates :name, presence: true
+  validates :radio_model, presence: true
+  validates :layout_definition, presence: true
+end

--- a/app/models/radio_model.rb
+++ b/app/models/radio_model.rb
@@ -1,8 +1,7 @@
 class RadioModel < ApplicationRecord
   # Associations
   belongs_to :manufacturer
-  # TODO: Uncomment when CodeplugLayout model is implemented
-  # has_many :codeplug_layouts, dependent: :restrict_with_error
+  has_many :codeplug_layouts, dependent: :restrict_with_error
 
   # Serialization
   serialize :supported_modes, type: Array, coder: JSON

--- a/db/migrate/20251102043923_create_codeplug_layouts.rb
+++ b/db/migrate/20251102043923_create_codeplug_layouts.rb
@@ -1,0 +1,14 @@
+class CreateCodeplugLayouts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :codeplug_layouts do |t|
+      t.references :radio_model, null: false, foreign_key: true
+      t.references :user, null: true, foreign_key: true
+      t.string :name, null: false
+      t.text :layout_definition, null: false
+
+      t.timestamps
+    end
+
+    add_index :codeplug_layouts, [ :radio_model_id, :name ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_02_015151) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_02_043923) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "codeplug_layouts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "layout_definition", null: false
+    t.string "name", null: false
+    t.bigint "radio_model_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["radio_model_id", "name"], name: "index_codeplug_layouts_on_radio_model_id_and_name"
+    t.index ["radio_model_id"], name: "index_codeplug_layouts_on_radio_model_id"
+    t.index ["user_id"], name: "index_codeplug_layouts_on_user_id"
+  end
 
   create_table "manufacturers", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -50,5 +62,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_02_015151) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "codeplug_layouts", "radio_models"
+  add_foreign_key "codeplug_layouts", "users"
   add_foreign_key "radio_models", "manufacturers"
 end

--- a/test/factories/codeplug_layouts.rb
+++ b/test/factories/codeplug_layouts.rb
@@ -1,0 +1,31 @@
+FactoryBot.define do
+  factory :codeplug_layout do
+    association :radio_model
+    name { "CHIRP CSV Format" }
+    layout_definition do
+      {
+        "columns" => [
+          { "header" => "Channel Name", "maps_to" => "long_name" },
+          { "header" => "RX Freq", "maps_to" => "system.rx_frequency" },
+          { "header" => "TX Freq", "maps_to" => "system.tx_frequency" },
+          { "header" => "Power", "maps_to" => "power_level" }
+        ]
+      }
+    end
+
+    # Optional user association - defaults to nil (system layout)
+    user { nil }
+
+    # Trait for user-created custom layout
+    trait :custom do
+      association :user
+      name { "Custom Layout" }
+    end
+
+    # Trait for system default layout
+    trait :system_default do
+      user { nil }
+      name { "System Default" }
+    end
+  end
+end

--- a/test/models/codeplug_layout_test.rb
+++ b/test/models/codeplug_layout_test.rb
@@ -1,0 +1,124 @@
+require "test_helper"
+
+class CodeplugLayoutTest < ActiveSupport::TestCase
+  # Basic Validation Tests
+  test "should save codeplug layout with valid attributes" do
+    codeplug_layout = build(:codeplug_layout)
+    assert codeplug_layout.save, "Failed to save codeplug layout with valid attributes"
+  end
+
+  test "should not save codeplug layout without name" do
+    codeplug_layout = build(:codeplug_layout, name: nil)
+    assert_not codeplug_layout.save, "Saved codeplug layout without name"
+    assert_includes codeplug_layout.errors[:name], "can't be blank"
+  end
+
+  test "should not save codeplug layout without radio_model" do
+    codeplug_layout = build(:codeplug_layout, radio_model: nil)
+    assert_not codeplug_layout.save, "Saved codeplug layout without radio_model"
+    assert_includes codeplug_layout.errors[:radio_model], "must exist"
+  end
+
+  test "should not save codeplug layout without layout_definition" do
+    codeplug_layout = build(:codeplug_layout, layout_definition: nil)
+    assert_not codeplug_layout.save, "Saved codeplug layout without layout_definition"
+    assert_includes codeplug_layout.errors[:layout_definition], "can't be blank"
+  end
+
+  test "should save codeplug layout with null user (system default)" do
+    codeplug_layout = build(:codeplug_layout, user: nil)
+    assert codeplug_layout.save, "Failed to save codeplug layout with null user"
+  end
+
+  test "should save codeplug layout with user (custom layout)" do
+    user = create(:user)
+    codeplug_layout = build(:codeplug_layout, user: user)
+    assert codeplug_layout.save, "Failed to save codeplug layout with user"
+  end
+
+  # Association Tests
+  test "should belong to radio_model" do
+    radio_model = create(:radio_model)
+    codeplug_layout = create(:codeplug_layout, radio_model: radio_model)
+    assert_equal radio_model, codeplug_layout.radio_model
+  end
+
+  test "should belong to user optionally" do
+    user = create(:user)
+    codeplug_layout = create(:codeplug_layout, user: user)
+    assert_equal user, codeplug_layout.user
+  end
+
+  test "should allow null user" do
+    codeplug_layout = create(:codeplug_layout, user: nil)
+    assert_nil codeplug_layout.user
+  end
+
+  # JSON Layout Definition Tests
+  test "should save codeplug layout with valid JSON layout_definition" do
+    layout_def = {
+      "columns" => [
+        { "header" => "Channel Name", "maps_to" => "long_name" },
+        { "header" => "RX Freq", "maps_to" => "system.rx_frequency" }
+      ]
+    }
+    codeplug_layout = build(:codeplug_layout, layout_definition: layout_def)
+    assert codeplug_layout.save, "Failed to save with valid layout_definition"
+  end
+
+  test "should save codeplug layout with complex layout_definition" do
+    layout_def = {
+      "columns" => [
+        { "header" => "Channel Name", "maps_to" => "long_name" },
+        { "header" => "RX Freq", "maps_to" => "system.rx_frequency" },
+        { "header" => "TX Freq", "maps_to" => "system.tx_frequency" },
+        { "header" => "Power", "maps_to" => "power_level" },
+        { "header" => "Talkgroup", "maps_to" => "system_talkgroup.talkgroup.name" }
+      ]
+    }
+    codeplug_layout = build(:codeplug_layout, layout_definition: layout_def)
+    assert codeplug_layout.save, "Failed to save with complex layout_definition"
+  end
+
+  # Serialization Tests
+  test "should properly serialize and deserialize layout_definition" do
+    layout_def = {
+      "columns" => [
+        { "header" => "Channel Name", "maps_to" => "long_name" },
+        { "header" => "RX Freq", "maps_to" => "system.rx_frequency" }
+      ]
+    }
+    codeplug_layout = create(:codeplug_layout, layout_definition: layout_def)
+    codeplug_layout.reload
+    assert_equal layout_def, codeplug_layout.layout_definition
+  end
+
+  test "should handle hash with symbol keys in layout_definition" do
+    layout_def = {
+      columns: [
+        { header: "Channel Name", maps_to: "long_name" }
+      ]
+    }
+    codeplug_layout = build(:codeplug_layout, layout_definition: layout_def)
+    assert codeplug_layout.save, "Failed to save with symbol keys"
+    codeplug_layout.reload
+    # After saving and reloading, keys should be strings
+    assert_equal "Channel Name", codeplug_layout.layout_definition["columns"][0]["header"]
+  end
+
+  # Uniqueness Tests
+  test "should allow multiple layouts for same radio_model" do
+    radio_model = create(:radio_model)
+    layout1 = create(:codeplug_layout, radio_model: radio_model, name: "Layout 1")
+    layout2 = build(:codeplug_layout, radio_model: radio_model, name: "Layout 2")
+    assert layout2.save, "Should allow multiple layouts for same radio_model"
+  end
+
+  test "should allow same name for different radio_models" do
+    radio_model1 = create(:radio_model)
+    radio_model2 = create(:radio_model)
+    layout1 = create(:codeplug_layout, radio_model: radio_model1, name: "CHIRP CSV")
+    layout2 = build(:codeplug_layout, radio_model: radio_model2, name: "CHIRP CSV")
+    assert layout2.save, "Should allow same name for different radio_models"
+  end
+end

--- a/test/models/radio_model_test.rb
+++ b/test/models/radio_model_test.rb
@@ -81,17 +81,16 @@ class RadioModelTest < ActiveSupport::TestCase
     assert_equal manufacturer, radio_model.manufacturer
   end
 
-  # TODO: Uncomment when CodeplugLayout model is implemented
-  # test "should respond to codeplug_layouts association" do
-  #   radio_model = build(:radio_model)
-  #   assert_respond_to radio_model, :codeplug_layouts
-  # end
+  test "should respond to codeplug_layouts association" do
+    radio_model = build(:radio_model)
+    assert_respond_to radio_model, :codeplug_layouts
+  end
 
-  # test "codeplug_layouts association should be configured" do
-  #   association = RadioModel.reflect_on_association(:codeplug_layouts)
-  #   assert_not_nil association, "codeplug_layouts association should exist"
-  #   assert_equal :has_many, association.macro
-  # end
+  test "codeplug_layouts association should be configured" do
+    association = RadioModel.reflect_on_association(:codeplug_layouts)
+    assert_not_nil association, "codeplug_layouts association should exist"
+    assert_equal :has_many, association.macro
+  end
 
   # Frequency Ranges Tests
   test "should save radio model with valid frequency ranges" do


### PR DESCRIPTION
## Summary
Created the CodeplugLayout model for defining CSV export formats for specific RadioModels. This model allows both system-provided layouts and user-created custom layouts.

## Implementation

### Model (`app/models/codeplug_layout.rb`)
**Associations:**
- `belongs_to :radio_model` (required)
- `belongs_to :user, optional: true` (null for system defaults, present for custom layouts)

**Serialization:**
- `layout_definition` serialized as Hash using JSON coder

**Validations:**
- Name presence
- RadioModel presence
- Layout definition presence

### Migration (`db/migrate/20251102043923_create_codeplug_layouts.rb`)
**Attributes:**
- `radio_model_id` (integer, foreign key, required)
- `user_id` (integer, foreign key, nullable)
- `name` (string, required)
- `layout_definition` (text/JSON, required)
- `timestamps`

**Indexes:**
- `radio_model_id` (via t.references with foreign key)
- `user_id` (via t.references with foreign key)
- Composite index on `[radio_model_id, name]`

### Layout Definition Format
JSON structure defining CSV column mappings for export:

```json
{
  "columns": [
    {"header": "Channel Name", "maps_to": "long_name"},
    {"header": "RX Freq", "maps_to": "system.rx_frequency"},
    {"header": "TX Freq", "maps_to": "system.tx_frequency"},
    {"header": "Power", "maps_to": "power_level"}
  ]
}
```

### Related Updates
- **RadioModel**: Uncommented `has_many :codeplug_layouts, dependent: :restrict_with_error`
- **RadioModel Tests**: Uncommented association tests (2 tests)

### Factory (`test/factories/codeplug_layouts.rb`)
- Default factory with valid layout_definition
- Trait `:custom` for user-created layouts
- Trait `:system_default` for system layouts

## Testing

### New Tests (15 added)
**Validation Tests:**
- Valid attributes
- Name presence
- RadioModel presence
- Layout definition presence
- Null user allowed (system default)
- User association (custom layout)

**Association Tests:**
- Belongs to radio_model
- Belongs to user optionally
- Allows null user

**JSON Serialization Tests:**
- Valid JSON layout_definition
- Complex layout_definition
- Serialize/deserialize round-trip
- Symbol keys conversion to string keys

**Business Logic Tests:**
- Multiple layouts per radio model
- Same name for different radio models

### Test Results
✅ **121 tests passing** (106 existing + 15 new)
✅ **267 assertions**
✅ **RuboCop clean** (53 files, 0 offenses)
✅ **Brakeman clean** (0 security warnings)

## Use Cases

### System Layouts
```ruby
# System-provided layout (user_id: null)
layout = CodeplugLayout.create!(
  radio_model: baofeng_uv5r,
  name: "CHIRP CSV Format",
  user: nil,
  layout_definition: { columns: [...] }
)
```

### Custom User Layouts
```ruby
# User-created custom layout
layout = CodeplugLayout.create!(
  radio_model: baofeng_uv5r,
  name: "My Custom Layout",
  user: current_user,
  layout_definition: { columns: [...] }
)
```

### Multiple Layouts Per Radio
```ruby
# Same radio can have multiple layouts
baofeng_uv5r.codeplug_layouts.create!(name: "CHIRP CSV", ...)
baofeng_uv5r.codeplug_layouts.create!(name: "RT Systems", ...)
baofeng_uv5r.codeplug_layouts.create!(name: "Custom Format", ...)
```

## Future Features
This model enables:
- CSV export service using layout definitions
- Field picker UI for creating custom layouts
- Layout sharing between users
- Import format detection and auto-mapping

## Acceptance Criteria
- ✅ CodeplugLayout model created with all attributes
- ✅ Model validations in place
- ✅ JSON serialization for layout_definition
- ✅ Database migration created with proper indexes
- ✅ Model tests written and passing
- ✅ All tests pass (121 tests, 267 assertions)
- ✅ RuboCop passes (53 files, 0 offenses)
- ✅ Brakeman passes (0 security warnings)

## Dependencies
- ✅ RadioModel model (#6) - Complete
- ✅ User model (#4) - Complete

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>