### PR TITLE
Implement Network model (#8)

### DIFF
--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -1,0 +1,12 @@
+class Network < ApplicationRecord
+  # Associations
+  # TODO: Uncomment when TalkGroup model is implemented
+  # has_many :talkgroups, dependent: :restrict_with_error
+
+  # TODO: Uncomment when SystemNetwork join model is implemented
+  # has_many :system_networks, dependent: :destroy
+  # has_many :systems, through: :system_networks
+
+  # Validations
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
+end

--- a/db/migrate/20251102154302_create_networks.rb
+++ b/db/migrate/20251102154302_create_networks.rb
@@ -1,0 +1,14 @@
+class CreateNetworks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :networks do |t|
+      t.string :name, null: false
+      t.text :description
+      t.string :website
+      t.string :network_type
+
+      t.timestamps
+    end
+
+    add_index :networks, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_02_043923) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_02_154302) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -31,6 +31,16 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_02_043923) do
     t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_manufacturers_on_name", unique: true
+  end
+
+  create_table "networks", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "name", null: false
+    t.string "network_type"
+    t.datetime "updated_at", null: false
+    t.string "website"
+    t.index ["name"], name: "index_networks_on_name", unique: true
   end
 
   create_table "radio_models", force: :cascade do |t|

--- a/test/factories/networks.rb
+++ b/test/factories/networks.rb
@@ -1,0 +1,39 @@
+FactoryBot.define do
+  factory :network do
+    sequence(:name) { |n| "Network #{n}" }
+    description { "A digital radio network" }
+    website { "https://example.com" }
+    network_type { "DMR" }
+
+    # Trait for Brandmeister
+    trait :brandmeister do
+      name { "Brandmeister" }
+      description { "Global DMR network" }
+      website { "https://brandmeister.network" }
+      network_type { "DMR" }
+    end
+
+    # Trait for DMRVA
+    trait :dmrva do
+      name { "DMRVA" }
+      description { "DMR network in Virginia" }
+      website { "https://dmrva.net" }
+      network_type { "DMR" }
+    end
+
+    # Trait for P25
+    trait :p25_network do
+      name { "P25 Network" }
+      description { "Project 25 digital network" }
+      network_type { "P25" }
+    end
+
+    # Trait for minimal network
+    trait :minimal do
+      name { "Minimal Network" }
+      description { nil }
+      website { nil }
+      network_type { nil }
+    end
+  end
+end

--- a/test/models/network_test.rb
+++ b/test/models/network_test.rb
@@ -1,0 +1,103 @@
+require "test_helper"
+
+class NetworkTest < ActiveSupport::TestCase
+  # Basic Validation Tests
+  test "should save network with valid attributes" do
+    network = build(:network)
+    assert network.save, "Failed to save network with valid attributes"
+  end
+
+  test "should not save network without name" do
+    network = build(:network, name: nil)
+    assert_not network.save, "Saved network without name"
+    assert_includes network.errors[:name], "can't be blank"
+  end
+
+  test "should not save network with duplicate name" do
+    existing_network = create(:network, name: "Brandmeister")
+    duplicate_network = build(:network, name: "Brandmeister")
+    assert_not duplicate_network.save, "Saved network with duplicate name"
+    assert_includes duplicate_network.errors[:name], "has already been taken"
+  end
+
+  test "should save network with unique name" do
+    create(:network, name: "Brandmeister")
+    network = build(:network, name: "DMRVA")
+    assert network.save, "Failed to save network with unique name"
+  end
+
+  # Attribute Tests
+  test "should save network with description" do
+    network = build(:network, description: "Global DMR network")
+    assert network.save, "Failed to save network with description"
+  end
+
+  test "should save network with website" do
+    network = build(:network, website: "https://brandmeister.network")
+    assert network.save, "Failed to save network with website"
+  end
+
+  test "should save network with network_type" do
+    network = build(:network, network_type: "DMR")
+    assert network.save, "Failed to save network with network_type"
+  end
+
+  test "should allow nil description" do
+    network = build(:network, description: nil)
+    assert network.save, "Failed to save network with nil description"
+  end
+
+  test "should allow nil website" do
+    network = build(:network, website: nil)
+    assert network.save, "Failed to save network with nil website"
+  end
+
+  test "should allow nil network_type" do
+    network = build(:network, network_type: nil)
+    assert network.save, "Failed to save network with nil network_type"
+  end
+
+  # Association Tests
+  # TODO: Uncomment when TalkGroup model is implemented
+  # test "should respond to talkgroups association" do
+  #   network = build(:network)
+  #   assert_respond_to network, :talkgroups
+  # end
+
+  # test "talkgroups association should be configured" do
+  #   association = Network.reflect_on_association(:talkgroups)
+  #   assert_not_nil association, "talkgroups association should exist"
+  #   assert_equal :has_many, association.macro
+  # end
+
+  # TODO: Uncomment when SystemNetwork join model is implemented
+  # test "should respond to system_networks association" do
+  #   network = build(:network)
+  #   assert_respond_to network, :system_networks
+  # end
+
+  # test "should respond to systems association" do
+  #   network = build(:network)
+  #   assert_respond_to network, :systems
+  # end
+
+  # test "systems association should be through system_networks" do
+  #   association = Network.reflect_on_association(:systems)
+  #   assert_not_nil association, "systems association should exist"
+  #   assert_equal :has_many, association.macro
+  #   assert_equal :system_networks, association.options[:through]
+  # end
+
+  # Case Sensitivity Tests
+  test "name uniqueness should be case insensitive" do
+    create(:network, name: "Brandmeister")
+    duplicate_network = build(:network, name: "BRANDMEISTER")
+    assert_not duplicate_network.save, "Saved network with case-insensitive duplicate name"
+  end
+
+  test "should save network with mixed case name if no exact match exists" do
+    create(:network, name: "brandmeister")
+    network = build(:network, name: "BrandMeister")
+    assert_not network.save, "Should not allow case variations of existing names"
+  end
+end


### PR DESCRIPTION
## Summary
Created the Network model for managing organizations/networks that operate TalkGroups (e.g., Brandmeister, DMRVA), following strict TDD workflow.

## Implementation

### Model (`app/models/network.rb`)

**Attributes:**
- `name` (string, required, unique, case-insensitive)
- `description` (text, optional)
- `website` (string, optional)
- `network_type` (string, optional) - e.g., "DMR", "P25", "NXDN"

**Validations:**
- Name presence
- Name uniqueness (case-insensitive)

**Associations (deferred for future implementation):**
```ruby
# TODO: Uncomment when TalkGroup model is implemented
# has_many :talkgroups, dependent: :restrict_with_error

# TODO: Uncomment when SystemNetwork join model is implemented
# has_many :system_networks, dependent: :destroy
# has_many :systems, through: :system_networks
```

These associations are documented in the model but commented out until the dependent models are created.

### Migration (`db/migrate/20251102154302_create_networks.rb`)

**Schema:**
- `name` (string, null: false)
- `description` (text)
- `website` (string)
- `network_type` (string)
- `timestamps`

**Indexes:**
- Unique index on `name` for enforcing uniqueness at database level

### Testing

**12 comprehensive tests covering:**

**Validation Tests:**
- Should save network with valid attributes
- Should not save without name
- Should not save with duplicate name
- Should save with unique name
- Name uniqueness is case-insensitive (BRANDMEISTER = brandmeister)
- Should not allow case variations of existing names

**Attribute Tests:**
- Should save with description
- Should save with website
- Should save with network_type
- Should allow nil description
- Should allow nil website
- Should allow nil network_type

**Association Tests (commented out for future):**
- Tests for talkgroups association (when TalkGroup model exists)
- Tests for system_networks association (when join model exists)
- Tests for systems through association

### Factory (`test/factories/networks.rb`)

**Default factory** with realistic data and sequence for unique names

**Traits:**
- `:brandmeister` - Brandmeister global DMR network
- `:dmrva` - DMRVA Virginia DMR network
- `:p25_network` - P25 digital network
- `:minimal` - Minimal network with only required name field

### Test Results
✅ **153 tests passing** (141 existing + 12 new)
✅ **326 assertions**
✅ **RuboCop clean** (59 files, 0 offenses)
✅ **Brakeman clean** (0 security warnings)

## Example Usage

### Creating Networks
```ruby
# Full network with all attributes
network = Network.create!(
  name: "Brandmeister",
  description: "Global DMR network",
  website: "https://brandmeister.network",
  network_type: "DMR"
)

# Minimal network (only name required)
network = Network.create!(name: "DMRVA")

# Using factory
network = create(:network, :brandmeister)
network = create(:network, :minimal)
```

### Case-Insensitive Uniqueness
```ruby
Network.create!(name: "Brandmeister")  # ✓ Success
Network.create!(name: "BRANDMEISTER")  # ✗ Validation error: name has already been taken
Network.create!(name: "brandmeister")  # ✗ Validation error: name has already been taken
```

### Network Types
```ruby
# Networks can be mode-specific or support multiple modes
Network.create!(name: "DMR Network", network_type: "DMR")
Network.create!(name: "P25 Network", network_type: "P25")
Network.create!(name: "Multi-Mode", network_type: "DMR,P25,NXDN")
Network.create!(name: "Generic", network_type: nil) # Type is optional
```

## Use Cases

Networks represent organizations or infrastructure that manage TalkGroups:

1. **DMR Networks**: Brandmeister, DMRVA, DMR-MARC
2. **P25 Networks**: State/regional P25 systems
3. **NXDN Networks**: NXDN trunking systems
4. **Multi-Mode Networks**: Networks supporting multiple protocols

Networks will later be associated with:
- **TalkGroups**: Networks organize and manage talkgroups
- **Systems**: Systems can connect to multiple networks (many-to-many through SystemNetwork)

## Future Enhancements

When dependent models are implemented, uncomment associations:
1. **TalkGroup model** (issue #9) - uncomment `has_many :talkgroups`
2. **SystemNetwork join model** - uncomment system associations
3. **System model** - complete the many-to-many relationship

## Acceptance Criteria
- ✅ Network model created with all attributes
- ✅ Model validations in place (name presence, case-insensitive uniqueness)
- ✅ Database migration created with proper indexes (unique index on name)
- ✅ Model tests written and passing (12 tests, all validation scenarios)
- ✅ All tests pass (153 tests, 326 assertions)
- ✅ RuboCop passes (59 files, 0 offenses)
- ✅ Brakeman passes (0 security warnings)

## Files Created
- `app/models/network.rb` - Network model with validations
- `db/migrate/20251102154302_create_networks.rb` - Database migration
- `test/models/network_test.rb` - 12 comprehensive tests
- `test/factories/networks.rb` - Factory with 4 traits

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>