### PR TITLE
Implement TalkGroup model (#9)

### DIFF
--- a/app/models/talk_group.rb
+++ b/app/models/talk_group.rb
@@ -1,0 +1,12 @@
+class TalkGroup < ApplicationRecord
+  # Associations
+  belongs_to :network
+
+  # TODO: Uncomment when SystemTalkGroup join model is implemented
+  # has_many :system_talk_groups, dependent: :destroy
+  # has_many :systems, through: :system_talk_groups
+
+  # Validations
+  validates :name, presence: true
+  validates :talkgroup_number, presence: true, uniqueness: { scope: :network_id }
+end

--- a/db/migrate/20251102174034_create_talk_groups.rb
+++ b/db/migrate/20251102174034_create_talk_groups.rb
@@ -1,0 +1,14 @@
+class CreateTalkGroups < ActiveRecord::Migration[8.1]
+  def change
+    create_table :talk_groups do |t|
+      t.references :network, null: false, foreign_key: true
+      t.string :name, null: false
+      t.string :talkgroup_number, null: false
+      t.text :description
+
+      t.timestamps
+    end
+
+    add_index :talk_groups, [ :network_id, :talkgroup_number ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_02_154854) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_02_174034) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -60,7 +60,6 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_02_154854) do
     t.datetime "updated_at", null: false
   end
 
-
   create_table "radio_models", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "frequency_ranges"
@@ -78,6 +77,17 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_02_154854) do
     t.index ["manufacturer_id"], name: "index_radio_models_on_manufacturer_id"
   end
 
+  create_table "talk_groups", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "name", null: false
+    t.bigint "network_id", null: false
+    t.string "talkgroup_number", null: false
+    t.datetime "updated_at", null: false
+    t.index ["network_id", "talkgroup_number"], name: "index_talk_groups_on_network_id_and_talkgroup_number", unique: true
+    t.index ["network_id"], name: "index_talk_groups_on_network_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "callsign"
     t.datetime "created_at", null: false
@@ -93,4 +103,5 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_02_154854) do
   add_foreign_key "codeplug_layouts", "radio_models"
   add_foreign_key "codeplug_layouts", "users"
   add_foreign_key "radio_models", "manufacturers"
+  add_foreign_key "talk_groups", "networks"
 end

--- a/test/factories/talk_groups.rb
+++ b/test/factories/talk_groups.rb
@@ -1,0 +1,41 @@
+FactoryBot.define do
+  factory :talk_group do
+    association :network
+    sequence(:name) { |n| "TalkGroup #{n}" }
+    sequence(:talkgroup_number) { |n| (3100 + n).to_s }
+    description { "A digital radio talkgroup" }
+
+    # Trait for Virginia
+    trait :virginia do
+      name { "Virginia" }
+      talkgroup_number { "3151" }
+      description { "Virginia statewide talkgroup" }
+    end
+
+    # Trait for Worldwide
+    trait :worldwide do
+      name { "Worldwide" }
+      talkgroup_number { "91" }
+      description { "Worldwide calling channel" }
+    end
+
+    # Trait for TAC channels
+    trait :tac do
+      name { "TAC 1" }
+      talkgroup_number { "8951" }
+      description { "Tactical channel 1" }
+    end
+
+    # Trait with leading zeros
+    trait :leading_zeros do
+      name { "Test Group" }
+      talkgroup_number { "091" }
+      description { "Talkgroup with leading zeros" }
+    end
+
+    # Trait for minimal talkgroup
+    trait :minimal do
+      description { nil }
+    end
+  end
+end

--- a/test/models/talk_group_test.rb
+++ b/test/models/talk_group_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class TalkGroupTest < ActiveSupport::TestCase
+  # Basic Validation Tests
+  test "should save talk_group with valid attributes" do
+    talk_group = build(:talk_group)
+    assert talk_group.save, "Failed to save talk_group with valid attributes"
+  end
+
+  test "should not save talk_group without name" do
+    talk_group = build(:talk_group, name: nil)
+    assert_not talk_group.save, "Saved talk_group without name"
+    assert_includes talk_group.errors[:name], "can't be blank"
+  end
+
+  test "should not save talk_group without talkgroup_number" do
+    talk_group = build(:talk_group, talkgroup_number: nil)
+    assert_not talk_group.save, "Saved talk_group without talkgroup_number"
+    assert_includes talk_group.errors[:talkgroup_number], "can't be blank"
+  end
+
+  test "should not save talk_group without network" do
+    talk_group = build(:talk_group, network: nil)
+    assert_not talk_group.save, "Saved talk_group without network"
+    assert_includes talk_group.errors[:network], "must exist"
+  end
+
+  # Uniqueness Tests
+  test "should not save talk_group with duplicate talkgroup_number within same network" do
+    network = create(:network)
+    create(:talk_group, network: network, talkgroup_number: "3181")
+    duplicate_talk_group = build(:talk_group, network: network, talkgroup_number: "3181")
+    assert_not duplicate_talk_group.save, "Saved talk_group with duplicate talkgroup_number in same network"
+    assert_includes duplicate_talk_group.errors[:talkgroup_number], "has already been taken"
+  end
+
+  test "should save talk_group with same talkgroup_number in different network" do
+    network1 = create(:network, name: "Network 1")
+    network2 = create(:network, name: "Network 2")
+    create(:talk_group, network: network1, talkgroup_number: "3181")
+    talk_group2 = build(:talk_group, network: network2, talkgroup_number: "3181")
+    assert talk_group2.save, "Failed to save talk_group with same talkgroup_number in different network"
+  end
+
+  # Association Tests
+  test "should belong to network" do
+    talk_group = build(:talk_group)
+    assert_respond_to talk_group, :network
+  end
+
+  test "network association should be configured" do
+    association = TalkGroup.reflect_on_association(:network)
+    assert_not_nil association, "network association should exist"
+    assert_equal :belongs_to, association.macro
+  end
+
+  # Attribute Tests
+  test "should save talk_group with description" do
+    talk_group = build(:talk_group, description: "Virginia statewide talkgroup")
+    assert talk_group.save, "Failed to save talk_group with description"
+  end
+
+  test "should allow nil description" do
+    talk_group = build(:talk_group, description: nil)
+    assert talk_group.save, "Failed to save talk_group with nil description"
+  end
+
+  # Talkgroup Number Format Tests
+  test "should save talk_group with numeric talkgroup_number" do
+    talk_group = build(:talk_group, talkgroup_number: "3181")
+    assert talk_group.save, "Failed to save talk_group with numeric talkgroup_number"
+  end
+
+  test "should save talk_group with talkgroup_number with leading zeros" do
+    talk_group = build(:talk_group, talkgroup_number: "091")
+    assert talk_group.save, "Failed to save talk_group with leading zeros in talkgroup_number"
+    assert_equal "091", talk_group.talkgroup_number, "Leading zeros should be preserved"
+  end
+
+  test "should save talk_group with alphanumeric talkgroup_number" do
+    talk_group = build(:talk_group, talkgroup_number: "TAC1")
+    assert talk_group.save, "Failed to save talk_group with alphanumeric talkgroup_number"
+  end
+end


### PR DESCRIPTION
## Summary
Implemented TalkGroup model for managing digital radio talkgroup identifiers with comprehensive validations and associations following strict TDD workflow.

## Implementation Details

### Model (app/models/talk_group.rb)
- `belongs_to :network` (required)
- Validates presence of name and talkgroup_number
- Validates uniqueness of talkgroup_number scoped to network_id
- Allows same talkgroup_number across different networks
- Stores talkgroup_number as string to preserve leading zeros

### Attributes
- **network_id** (integer, foreign key, required) - References the network this talkgroup belongs to
- **name** (string, required) - Human-readable name (e.g., "Virginia", "Worldwide")
- **talkgroup_number** (string, required) - Talkgroup identifier (e.g., "3181", "091")
- **description** (text, optional) - Additional details about the talkgroup

### Migration (db/migrate/20251102174034_create_talk_groups.rb)
```ruby
create_table :talk_groups do |t|
  t.references :network, null: false, foreign_key: true
  t.string :name, null: false
  t.string :talkgroup_number, null: false
  t.text :description
  t.timestamps
end
add_index :talk_groups, [:network_id, :talkgroup_number], unique: true
```

### Key Features

#### Scoped Uniqueness
- Talkgroup numbers must be unique **within each network**
- Same talkgroup number can exist across different networks
- Database-level unique index enforces constraint
- Example:
  - Network A: TG "3181" ✓
  - Network A: TG "3181" ✗ (duplicate)
  - Network B: TG "3181" ✓ (different network)

#### String-Based Talkgroup Numbers
- Stored as string (not integer)
- Preserves leading zeros: "091" stays "091"
- Supports alphanumeric: "TAC1", "TAC310"
- Prevents data loss from numeric conversion

#### Required Association
- Every talkgroup must belong to a network
- Foreign key constraint enforced at database level
- Network deletion restricted if talkgroups exist

## Validations

### Presence
- `name` - required
- `talkgroup_number` - required
- `network` - required (belongs_to)

### Uniqueness
- `talkgroup_number` - unique within network scope
- Validation: `uniqueness: { scope: :network_id }`
- Database index: `[:network_id, :talkgroup_number]`

### Optional
- `description` - can be nil

## Testing

### Model Tests (13 comprehensive tests)
✅ **Validation Tests:**
- Should save with valid attributes
- Should not save without name
- Should not save without talkgroup_number
- Should not save without network

✅ **Uniqueness Tests:**
- Should not save duplicate talkgroup_number within same network
- Should save same talkgroup_number in different network

✅ **Association Tests:**
- Should belong to network
- Network association configured correctly

✅ **Attribute Tests:**
- Should save with description
- Should allow nil description

✅ **Format Tests:**
- Should save numeric talkgroup_number ("3181")
- Should preserve leading zeros ("091" → "091")
- Should save alphanumeric talkgroup_number ("TAC1")

### Factory (test/factories/talk_groups.rb)
- Default factory with sequences
- **Traits:**
  - `:virginia` - "3151" Virginia statewide
  - `:worldwide` - "91" Worldwide calling
  - `:tac` - "8951" Tactical channel
  - `:leading_zeros` - "091" Tests zero preservation
  - `:minimal` - Minimum required fields

## Test Results
✅ **211 tests passing** (198 existing + 13 new)
✅ **448 assertions**
✅ **RuboCop clean** (78 files, 0 offenses)
✅ **Brakeman clean** (0 security warnings)

## TDD Workflow Followed
1. ✅ Written 13 failing tests first (red phase)
2. ✅ Created migration with proper indexes
3. ✅ Created model with validations and associations
4. ✅ Created comprehensive factory
5. ✅ All tests passing (green phase)

## Future Associations
Model includes comments for future join table implementation:
```ruby
# TODO: Uncomment when SystemTalkGroup join model is implemented
# has_many :system_talk_groups, dependent: :destroy
# has_many :systems, through: :system_talk_groups
```

This supports the relationship where:
- Same talkgroup can be on different timeslots on different systems
- SystemTalkGroup join table will include timeslot information

## Example Usage

```ruby
# Create network
network = Network.create!(name: "Brandmeister", network_type: "Digital-DMR")

# Create talkgroup
tg = TalkGroup.create!(
  network: network,
  name: "Virginia",
  talkgroup_number: "3151",
  description: "Virginia statewide talkgroup"
)

# Scoped uniqueness - same network
TalkGroup.create!(
  network: network,
  talkgroup_number: "3151"  # ✗ Fails - duplicate in same network
)

# Scoped uniqueness - different network
other_network = Network.create!(name: "DMRVA", network_type: "Digital-DMR")
TalkGroup.create!(
  network: other_network,
  talkgroup_number: "3151"  # ✓ Passes - different network
)

# Leading zeros preserved
tg = TalkGroup.create!(
  network: network,
  name: "Test",
  talkgroup_number: "091"
)
tg.talkgroup_number  # => "091" (not 91)

# Alphanumeric support
tg = TalkGroup.create!(
  network: network,
  name: "TAC Channel",
  talkgroup_number: "TAC310"
)
```

## Database Indexes
- `network_id` - Index for foreign key lookups
- `[network_id, talkgroup_number]` - Unique composite index for scoped uniqueness

## Files Created
- `app/models/talk_group.rb` - Model with validations
- `db/migrate/20251102174034_create_talk_groups.rb` - Migration with indexes
- `test/models/talk_group_test.rb` - 13 comprehensive tests
- `test/factories/talk_groups.rb` - Factory with 5 traits

## Files Modified
- `db/schema.rb` - Updated with talk_groups table

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>