### PR TITLE
Implement TalkGroup views and CRUD operations (#25)

### DIFF
--- a/app/controllers/talk_groups_controller.rb
+++ b/app/controllers/talk_groups_controller.rb
@@ -1,0 +1,59 @@
+class TalkGroupsController < ApplicationController
+  before_action :set_talk_group, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    if params[:network_id].present?
+      @talk_groups = TalkGroup.where(network_id: params[:network_id]).order(:talkgroup_number)
+    else
+      @talk_groups = TalkGroup.includes(:network).order(:talkgroup_number)
+    end
+  end
+
+  def show
+    # Display talk group details
+  end
+
+  def new
+    @talk_group = TalkGroup.new
+    @networks = Network.order(:name)
+  end
+
+  def edit
+    @networks = Network.order(:name)
+  end
+
+  def create
+    @talk_group = TalkGroup.new(talk_group_params)
+
+    if @talk_group.save
+      redirect_to talk_group_path(@talk_group), notice: "TalkGroup was successfully created."
+    else
+      @networks = Network.order(:name)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @talk_group.update(talk_group_params)
+      redirect_to talk_group_path(@talk_group), notice: "TalkGroup was successfully updated."
+    else
+      @networks = Network.order(:name)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @talk_group.destroy!
+    redirect_to talk_groups_path, notice: "TalkGroup was successfully deleted."
+  end
+
+  private
+
+  def set_talk_group
+    @talk_group = TalkGroup.find(params[:id])
+  end
+
+  def talk_group_params
+    params.require(:talk_group).permit(:network_id, :name, :talkgroup_number, :description)
+  end
+end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -34,6 +34,9 @@
           <li class="nav-item">
             <%= link_to "Networks", networks_path, class: "nav-link #{request.path.start_with?('/networks') ? 'active' : ''}" %>
           </li>
+          <li class="nav-item">
+            <%= link_to "TalkGroups", talk_groups_path, class: "nav-link #{request.path.start_with?('/talk_groups') ? 'active' : ''}" %>
+          </li>
         <% end %>
       </ul>
 

--- a/app/views/talk_groups/_form.html.erb
+++ b/app/views/talk_groups/_form.html.erb
@@ -1,0 +1,43 @@
+<%= form_with model: talk_group do |f| %>
+  <% if talk_group.errors.any? %>
+    <div class="alert alert-danger">
+      <h5><%= pluralize(talk_group.errors.count, "error") %> prohibited this talkgroup from being saved:</h5>
+      <ul>
+        <% talk_group.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mb-3">
+    <%= f.label :network_id, "Network", class: "form-label" %>
+    <%= f.collection_select :network_id, @networks, :id, :name,
+        { prompt: "Select a network" },
+        { class: "form-select", required: true } %>
+    <div class="form-text">The network this talkgroup belongs to</div>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :name, class: "form-label" %>
+    <%= f.text_field :name, class: "form-control", required: true, placeholder: "e.g., Virginia, Worldwide" %>
+    <div class="form-text">Human-readable name for the talkgroup</div>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :talkgroup_number, "TalkGroup Number", class: "form-label" %>
+    <%= f.text_field :talkgroup_number, class: "form-control", required: true, placeholder: "e.g., 3151, 91" %>
+    <div class="form-text">The talkgroup identifier (stored as string to preserve leading zeros)</div>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :description, class: "form-label" %>
+    <%= f.text_area :description, class: "form-control", rows: 4, placeholder: "Optional description of the talkgroup" %>
+    <div class="form-text">Additional details about the talkgroup and its coverage</div>
+  </div>
+
+  <div class="d-flex gap-2">
+    <%= f.submit class: "btn btn-primary" %>
+    <%= link_to "Cancel", talk_group.persisted? ? talk_group_path(talk_group) : talk_groups_path, class: "btn btn-secondary" %>
+  </div>
+<% end %>

--- a/app/views/talk_groups/edit.html.erb
+++ b/app/views/talk_groups/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="container mt-4">
+  <h1>Edit TalkGroup</h1>
+  <div class="card mt-4">
+    <div class="card-body">
+      <%= render "form", talk_group: @talk_group %>
+    </div>
+  </div>
+</div>

--- a/app/views/talk_groups/index.html.erb
+++ b/app/views/talk_groups/index.html.erb
@@ -1,0 +1,51 @@
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>TalkGroups</h1>
+    <%= link_to "New TalkGroup", new_talk_group_path, class: "btn btn-primary" %>
+  </div>
+
+  <% if params[:network_id].present? %>
+    <div class="alert alert-info">
+      Showing talkgroups for network: <strong><%= Network.find(params[:network_id]).name %></strong>
+      <%= link_to "Show all talkgroups", talk_groups_path, class: "alert-link ms-2" %>
+    </div>
+  <% end %>
+
+  <% if @talk_groups.any? %>
+    <div class="table-responsive">
+      <table class="table table-striped table-hover">
+        <thead>
+          <tr>
+            <th>Number</th>
+            <th>Name</th>
+            <th>Network</th>
+            <th>Description</th>
+            <th class="text-end">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @talk_groups.each do |talk_group| %>
+            <tr>
+              <td><%= talk_group.talkgroup_number %></td>
+              <td><%= link_to talk_group.name, talk_group_path(talk_group) %></td>
+              <td><%= link_to talk_group.network.name, network_path(talk_group.network) %></td>
+              <td><%= talk_group.description.present? ? truncate(talk_group.description, length: 50) : "" %></td>
+              <td class="text-end">
+                <%= link_to "View", talk_group_path(talk_group), class: "btn btn-sm btn-info me-1" %>
+                <%= link_to "Edit", edit_talk_group_path(talk_group), class: "btn btn-sm btn-secondary me-1" %>
+                <%= button_to "Delete", talk_group_path(talk_group), method: :delete,
+                    class: "btn btn-sm btn-danger",
+                    form: { class: "d-inline" },
+                    data: { confirm: "Are you sure?" } %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="alert alert-info">
+      No talkgroups found. <%= link_to "Create the first one", new_talk_group_path, class: "alert-link" %>.
+    </div>
+  <% end %>
+</div>

--- a/app/views/talk_groups/new.html.erb
+++ b/app/views/talk_groups/new.html.erb
@@ -1,0 +1,8 @@
+<div class="container mt-4">
+  <h1>New TalkGroup</h1>
+  <div class="card mt-4">
+    <div class="card-body">
+      <%= render "form", talk_group: @talk_group %>
+    </div>
+  </div>
+</div>

--- a/app/views/talk_groups/show.html.erb
+++ b/app/views/talk_groups/show.html.erb
@@ -1,0 +1,32 @@
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1><%= @talk_group.name %></h1>
+    <div>
+      <%= link_to "Edit", edit_talk_group_path(@talk_group), class: "btn btn-secondary me-1" %>
+      <%= button_to "Delete", talk_group_path(@talk_group), method: :delete,
+          class: "btn btn-danger me-1",
+          form: { class: "d-inline" },
+          data: { confirm: "Are you sure?" } %>
+      <%= link_to "Back", talk_groups_path, class: "btn btn-outline-secondary" %>
+    </div>
+  </div>
+
+  <div class="card mb-4">
+    <div class="card-body">
+      <h5 class="card-title">TalkGroup Details</h5>
+      <dl class="row mb-0">
+        <dt class="col-sm-3">Name:</dt>
+        <dd class="col-sm-9"><%= @talk_group.name %></dd>
+
+        <dt class="col-sm-3">TalkGroup Number:</dt>
+        <dd class="col-sm-9"><%= @talk_group.talkgroup_number %></dd>
+
+        <dt class="col-sm-3">Network:</dt>
+        <dd class="col-sm-9"><%= link_to @talk_group.network.name, network_path(@talk_group.network) %></dd>
+
+        <dt class="col-sm-3">Description:</dt>
+        <dd class="col-sm-9"><%= @talk_group.description.presence || "Not specified" %></dd>
+      </dl>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
 
   # Networks and talkgroups
   resources :networks
+  resources :talk_groups
 
   # Static pages
   get "help", to: "pages#help"

--- a/test/controllers/talk_groups_controller_test.rb
+++ b/test/controllers/talk_groups_controller_test.rb
@@ -1,0 +1,204 @@
+require "test_helper"
+
+class TalkGroupsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    log_in_as(@user)
+    @network = create(:network)
+    @talk_group = create(:talk_group, network: @network)
+  end
+
+  # Index Tests
+  test "should get index" do
+    get talk_groups_path
+    assert_response :success
+  end
+
+  test "index should display talk groups" do
+    get talk_groups_path
+    assert_select "h1", "TalkGroups"
+  end
+
+  test "index should display talk group names and numbers" do
+    tg1 = create(:talk_group, network: @network, name: "Virginia", talkgroup_number: "3151")
+    tg2 = create(:talk_group, network: @network, name: "Worldwide", talkgroup_number: "91")
+    get talk_groups_path
+    assert_select "td", tg1.name
+    assert_select "td", tg1.talkgroup_number
+    assert_select "td", tg2.name
+    assert_select "td", tg2.talkgroup_number
+  end
+
+  test "index should filter by network" do
+    network2 = create(:network, name: "DMRVA")
+    tg1 = create(:talk_group, network: @network, name: "Network 1 TG")
+    tg2 = create(:talk_group, network: network2, name: "Network 2 TG")
+
+    get talk_groups_path, params: { network_id: @network.id }
+    assert_response :success
+    assert_select "td", tg1.name
+    assert_select "td", { text: tg2.name, count: 0 }
+  end
+
+  # Show Tests
+  test "should get show" do
+    get talk_group_path(@talk_group)
+    assert_response :success
+  end
+
+  test "show should display talk group name" do
+    get talk_group_path(@talk_group)
+    assert_select "h1", @talk_group.name
+  end
+
+  test "show should display talk group details" do
+    tg = create(:talk_group,
+      network: @network,
+      name: "Virginia",
+      talkgroup_number: "3151",
+      description: "Virginia statewide talkgroup")
+    get talk_group_path(tg)
+    assert_select "dd", "Virginia"
+    assert_select "dd", "3151"
+    assert_select "dd", "Virginia statewide talkgroup"
+  end
+
+  # New Tests
+  test "should get new" do
+    get new_talk_group_path
+    assert_response :success
+  end
+
+  test "new should display form" do
+    get new_talk_group_path
+    assert_select "form"
+  end
+
+  # Create Tests
+  test "should create talk_group with valid attributes" do
+    assert_difference("TalkGroup.count", 1) do
+      post talk_groups_path, params: {
+        talk_group: {
+          network_id: @network.id,
+          name: "Test TalkGroup",
+          talkgroup_number: "9999"
+        }
+      }
+    end
+    assert_redirected_to talk_group_path(TalkGroup.last)
+  end
+
+  test "should create talk_group with all attributes" do
+    assert_difference("TalkGroup.count", 1) do
+      post talk_groups_path, params: {
+        talk_group: {
+          network_id: @network.id,
+          name: "Full TalkGroup",
+          talkgroup_number: "8888",
+          description: "A complete talkgroup"
+        }
+      }
+    end
+    tg = TalkGroup.last
+    assert_equal "Full TalkGroup", tg.name
+    assert_equal "8888", tg.talkgroup_number
+    assert_equal "A complete talkgroup", tg.description
+    assert_equal @network, tg.network
+  end
+
+  test "should not create talk_group with invalid attributes" do
+    assert_no_difference("TalkGroup.count") do
+      post talk_groups_path, params: {
+        talk_group: {
+          network_id: @network.id,
+          name: ""
+        }
+      }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test "should not create talk_group with duplicate talkgroup_number in same network" do
+    create(:talk_group, network: @network, talkgroup_number: "3151")
+    assert_no_difference("TalkGroup.count") do
+      post talk_groups_path, params: {
+        talk_group: {
+          network_id: @network.id,
+          name: "Duplicate",
+          talkgroup_number: "3151"
+        }
+      }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  # Edit Tests
+  test "should get edit" do
+    get edit_talk_group_path(@talk_group)
+    assert_response :success
+  end
+
+  test "edit should display form with existing values" do
+    get edit_talk_group_path(@talk_group)
+    assert_select "form"
+    assert_select "input[value=?]", @talk_group.name
+  end
+
+  # Update Tests
+  test "should update talk_group with valid attributes" do
+    patch talk_group_path(@talk_group), params: {
+      talk_group: {
+        name: "Updated Name"
+      }
+    }
+    assert_redirected_to talk_group_path(@talk_group)
+    @talk_group.reload
+    assert_equal "Updated Name", @talk_group.name
+  end
+
+  test "should update talk_group with all attributes" do
+    patch talk_group_path(@talk_group), params: {
+      talk_group: {
+        name: "Updated TalkGroup",
+        talkgroup_number: "7777",
+        description: "Updated description"
+      }
+    }
+    assert_redirected_to talk_group_path(@talk_group)
+    @talk_group.reload
+    assert_equal "Updated TalkGroup", @talk_group.name
+    assert_equal "7777", @talk_group.talkgroup_number
+    assert_equal "Updated description", @talk_group.description
+  end
+
+  test "should not update talk_group with invalid attributes" do
+    original_name = @talk_group.name
+    patch talk_group_path(@talk_group), params: {
+      talk_group: {
+        name: ""
+      }
+    }
+    assert_response :unprocessable_entity
+    @talk_group.reload
+    assert_equal original_name, @talk_group.name
+  end
+
+  # Destroy Tests
+  test "should destroy talk_group" do
+    assert_difference("TalkGroup.count", -1) do
+      delete talk_group_path(@talk_group)
+    end
+    assert_redirected_to talk_groups_path
+    assert_equal "TalkGroup was successfully deleted.", flash[:notice]
+  end
+
+  private
+
+  # Helper method to simulate user login
+  def log_in_as(user)
+    post login_path, params: {
+      email: user.email,
+      password: "password123"
+    }
+  end
+end

--- a/test/system/navbar_test.rb
+++ b/test/system/navbar_test.rb
@@ -163,4 +163,32 @@ class NavbarTest < ApplicationSystemTestCase
 
     assert_current_path networks_path
   end
+
+  test "navbar shows TalkGroups link when authenticated" do
+    user = create(:user, email: "test@example.com", password: "password123")
+
+    visit login_path
+    fill_in "Email", with: "test@example.com"
+    fill_in "Password", with: "password123"
+    click_button "Log In"
+
+    within "nav.navbar" do
+      assert_link "TalkGroups"
+    end
+  end
+
+  test "navbar TalkGroups link works" do
+    user = create(:user, email: "test@example.com", password: "password123")
+
+    visit login_path
+    fill_in "Email", with: "test@example.com"
+    fill_in "Password", with: "password123"
+    click_button "Log In"
+
+    within "nav.navbar" do
+      click_link "TalkGroups"
+    end
+
+    assert_current_path talk_groups_path
+  end
 end


### PR DESCRIPTION
See commit message for full details.

## Summary
Implemented TalkGroupsController with full CRUD operations and network filtering.

## Key Features
- Network filtering on index page
- Scoped uniqueness validation
- Bootstrap 5 styling
- Navbar integration

## Test Results
✅ 259 tests passing (21 new)
✅ 547 assertions
✅ RuboCop clean
✅ Brakeman clean

Closes #25