### PR TITLE
Implement SystemNetwork join table (#12)

### DIFF
--- a/app/models/system_network.rb
+++ b/app/models/system_network.rb
@@ -1,0 +1,8 @@
+class SystemNetwork < ApplicationRecord
+  # Associations
+  belongs_to :system
+  belongs_to :network
+
+  # Validations
+  validates :system_id, uniqueness: { scope: :network_id }
+end

--- a/db/migrate/20251102232504_create_system_networks.rb
+++ b/db/migrate/20251102232504_create_system_networks.rb
@@ -1,0 +1,12 @@
+class CreateSystemNetworks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :system_networks do |t|
+      t.references :system, null: false, foreign_key: true
+      t.references :network, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :system_networks, [ :system_id, :network_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_02_175353) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_02_232504) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -77,6 +77,16 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_02_175353) do
     t.index ["manufacturer_id"], name: "index_radio_models_on_manufacturer_id"
   end
 
+  create_table "system_networks", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "network_id", null: false
+    t.bigint "system_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["network_id"], name: "index_system_networks_on_network_id"
+    t.index ["system_id", "network_id"], name: "index_system_networks_on_system_id_and_network_id", unique: true
+    t.index ["system_id"], name: "index_system_networks_on_system_id"
+  end
+
   create_table "systems", force: :cascade do |t|
     t.string "bandwidth"
     t.string "city"
@@ -127,5 +137,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_02_175353) do
   add_foreign_key "codeplug_layouts", "radio_models"
   add_foreign_key "codeplug_layouts", "users"
   add_foreign_key "radio_models", "manufacturers"
+  add_foreign_key "system_networks", "networks"
+  add_foreign_key "system_networks", "systems"
   add_foreign_key "talk_groups", "networks"
 end

--- a/test/factories/system_networks.rb
+++ b/test/factories/system_networks.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :system_network do
+    association :system
+    association :network
+  end
+end

--- a/test/models/system_network_test.rb
+++ b/test/models/system_network_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+class SystemNetworkTest < ActiveSupport::TestCase
+  # Basic Validation Tests
+  test "should save system_network with valid attributes" do
+    system_network = build(:system_network)
+    assert system_network.save, "Failed to save system_network with valid attributes"
+  end
+
+  test "should not save system_network without system" do
+    system_network = build(:system_network, system: nil)
+    assert_not system_network.save, "Saved system_network without system"
+    assert_includes system_network.errors[:system], "must exist"
+  end
+
+  test "should not save system_network without network" do
+    system_network = build(:system_network, network: nil)
+    assert_not system_network.save, "Saved system_network without network"
+    assert_includes system_network.errors[:network], "must exist"
+  end
+
+  # Uniqueness Tests
+  test "should not save system_network with duplicate system and network combination" do
+    system = create(:system)
+    network = create(:network)
+    create(:system_network, system: system, network: network)
+
+    duplicate = build(:system_network, system: system, network: network)
+    assert_not duplicate.save, "Saved system_network with duplicate system/network combination"
+    assert_includes duplicate.errors[:system_id], "has already been taken"
+  end
+
+  test "should save system_network with same system but different network" do
+    system = create(:system)
+    network1 = create(:network, name: "Network 1")
+    network2 = create(:network, name: "Network 2")
+
+    create(:system_network, system: system, network: network1)
+    system_network2 = build(:system_network, system: system, network: network2)
+
+    assert system_network2.save, "Failed to save system_network with same system but different network"
+  end
+
+  test "should save system_network with same network but different system" do
+    system1 = create(:system, name: "System 1")
+    system2 = create(:system, name: "System 2")
+    network = create(:network)
+
+    create(:system_network, system: system1, network: network)
+    system_network2 = build(:system_network, system: system2, network: network)
+
+    assert system_network2.save, "Failed to save system_network with same network but different system"
+  end
+
+  # Association Tests
+  test "should belong to system" do
+    system_network = build(:system_network)
+    assert_respond_to system_network, :system
+  end
+
+  test "should belong to network" do
+    system_network = build(:system_network)
+    assert_respond_to system_network, :network
+  end
+
+  test "system association should be configured" do
+    association = SystemNetwork.reflect_on_association(:system)
+    assert_not_nil association, "system association should exist"
+    assert_equal :belongs_to, association.macro
+  end
+
+  test "network association should be configured" do
+    association = SystemNetwork.reflect_on_association(:network)
+    assert_not_nil association, "network association should exist"
+    assert_equal :belongs_to, association.macro
+  end
+end


### PR DESCRIPTION
Join table for many-to-many relationship between Systems and Networks.

## Implementation

- SystemNetwork model with belongs_to :system and :network
- Validates uniqueness of system_id scoped to network_id
- Database migration with unique index on [system_id, network_id]
- Factory with associations
- 10 comprehensive model tests

## Test Results
✅ 286 tests passing (10 new)
✅ 604 assertions
✅ RuboCop clean (90 files, 0 offenses)
✅ Brakeman clean (0 security warnings)

Closes #12