### PR TITLE
Implement SystemTalkGroup join table (#13)

### DIFF
--- a/app/models/system_talk_group.rb
+++ b/app/models/system_talk_group.rb
@@ -1,0 +1,12 @@
+class SystemTalkGroup < ApplicationRecord
+  # Associations
+  belongs_to :system
+  belongs_to :talk_group
+
+  # TODO: Uncomment when Channel model is implemented
+  # has_many :channels
+
+  # Validations
+  validates :system_id, uniqueness: { scope: [ :talk_group_id, :timeslot ] }
+  validates :timeslot, inclusion: { in: [ 1, 2 ], message: "must be 1 or 2" }, allow_nil: true
+end

--- a/db/migrate/20251103003351_create_system_talk_groups.rb
+++ b/db/migrate/20251103003351_create_system_talk_groups.rb
@@ -1,0 +1,13 @@
+class CreateSystemTalkGroups < ActiveRecord::Migration[8.1]
+  def change
+    create_table :system_talk_groups do |t|
+      t.references :system, null: false, foreign_key: true
+      t.references :talk_group, null: false, foreign_key: true
+      t.integer :timeslot
+
+      t.timestamps
+    end
+
+    add_index :system_talk_groups, [ :system_id, :talk_group_id, :timeslot ], unique: true, name: "index_system_talk_groups_unique"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_02_232504) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_03_003351) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -87,6 +87,17 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_02_232504) do
     t.index ["system_id"], name: "index_system_networks_on_system_id"
   end
 
+  create_table "system_talk_groups", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "system_id", null: false
+    t.bigint "talk_group_id", null: false
+    t.integer "timeslot"
+    t.datetime "updated_at", null: false
+    t.index ["system_id", "talk_group_id", "timeslot"], name: "index_system_talk_groups_unique", unique: true
+    t.index ["system_id"], name: "index_system_talk_groups_on_system_id"
+    t.index ["talk_group_id"], name: "index_system_talk_groups_on_talk_group_id"
+  end
+
   create_table "systems", force: :cascade do |t|
     t.string "bandwidth"
     t.string "city"
@@ -139,5 +150,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_02_232504) do
   add_foreign_key "radio_models", "manufacturers"
   add_foreign_key "system_networks", "networks"
   add_foreign_key "system_networks", "systems"
+  add_foreign_key "system_talk_groups", "systems"
+  add_foreign_key "system_talk_groups", "talk_groups"
   add_foreign_key "talk_groups", "networks"
 end

--- a/test/factories/system_talk_groups.rb
+++ b/test/factories/system_talk_groups.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :system_talk_group do
+    association :system
+    association :talk_group
+    timeslot { 1 }
+
+    # Trait for timeslot 2
+    trait :timeslot_2 do
+      timeslot { 2 }
+    end
+
+    # Trait for nil timeslot (non-DMR systems)
+    trait :no_timeslot do
+      timeslot { nil }
+    end
+  end
+end

--- a/test/models/system_talk_group_test.rb
+++ b/test/models/system_talk_group_test.rb
@@ -1,0 +1,110 @@
+require "test_helper"
+
+class SystemTalkGroupTest < ActiveSupport::TestCase
+  # Basic Validation Tests
+  test "should save system_talk_group with valid attributes" do
+    system_talk_group = build(:system_talk_group)
+    assert system_talk_group.save, "Failed to save system_talk_group with valid attributes"
+  end
+
+  test "should not save system_talk_group without system" do
+    system_talk_group = build(:system_talk_group, system: nil)
+    assert_not system_talk_group.save, "Saved system_talk_group without system"
+    assert_includes system_talk_group.errors[:system], "must exist"
+  end
+
+  test "should not save system_talk_group without talk_group" do
+    system_talk_group = build(:system_talk_group, talk_group: nil)
+    assert_not system_talk_group.save, "Saved system_talk_group without talk_group"
+    assert_includes system_talk_group.errors[:talk_group], "must exist"
+  end
+
+  # Timeslot Validation Tests
+  test "should save system_talk_group with nil timeslot" do
+    system_talk_group = build(:system_talk_group, timeslot: nil)
+    assert system_talk_group.save, "Failed to save system_talk_group with nil timeslot"
+  end
+
+  test "should save system_talk_group with timeslot 1" do
+    system_talk_group = build(:system_talk_group, timeslot: 1)
+    assert system_talk_group.save, "Failed to save system_talk_group with timeslot 1"
+  end
+
+  test "should save system_talk_group with timeslot 2" do
+    system_talk_group = build(:system_talk_group, timeslot: 2)
+    assert system_talk_group.save, "Failed to save system_talk_group with timeslot 2"
+  end
+
+  test "should not save system_talk_group with timeslot 0" do
+    system_talk_group = build(:system_talk_group, timeslot: 0)
+    assert_not system_talk_group.save, "Saved system_talk_group with timeslot 0"
+    assert_includes system_talk_group.errors[:timeslot], "must be 1 or 2"
+  end
+
+  test "should not save system_talk_group with timeslot 3" do
+    system_talk_group = build(:system_talk_group, timeslot: 3)
+    assert_not system_talk_group.save, "Saved system_talk_group with timeslot 3"
+    assert_includes system_talk_group.errors[:timeslot], "must be 1 or 2"
+  end
+
+  # Uniqueness Tests
+  test "should not save system_talk_group with duplicate system, talk_group, and timeslot" do
+    system = create(:system)
+    talk_group = create(:talk_group)
+    create(:system_talk_group, system: system, talk_group: talk_group, timeslot: 1)
+
+    duplicate = build(:system_talk_group, system: system, talk_group: talk_group, timeslot: 1)
+    assert_not duplicate.save, "Saved system_talk_group with duplicate system/talk_group/timeslot"
+    assert_includes duplicate.errors[:system_id], "has already been taken"
+  end
+
+  test "should save system_talk_group with same system and talk_group but different timeslot" do
+    system = create(:system)
+    talk_group = create(:talk_group)
+    create(:system_talk_group, system: system, talk_group: talk_group, timeslot: 1)
+
+    stg2 = build(:system_talk_group, system: system, talk_group: talk_group, timeslot: 2)
+    assert stg2.save, "Failed to save system_talk_group with different timeslot"
+  end
+
+  test "should save system_talk_group with same system and talk_group but one nil timeslot" do
+    system = create(:system)
+    talk_group = create(:talk_group)
+    create(:system_talk_group, system: system, talk_group: talk_group, timeslot: 1)
+
+    stg2 = build(:system_talk_group, system: system, talk_group: talk_group, timeslot: nil)
+    assert stg2.save, "Failed to save system_talk_group with nil timeslot"
+  end
+
+  test "should not save system_talk_group with duplicate system, talk_group, and nil timeslot" do
+    system = create(:system)
+    talk_group = create(:talk_group)
+    create(:system_talk_group, system: system, talk_group: talk_group, timeslot: nil)
+
+    duplicate = build(:system_talk_group, system: system, talk_group: talk_group, timeslot: nil)
+    assert_not duplicate.save, "Saved system_talk_group with duplicate system/talk_group/nil timeslot"
+  end
+
+  # Association Tests
+  test "should belong to system" do
+    system_talk_group = build(:system_talk_group)
+    assert_respond_to system_talk_group, :system
+  end
+
+  test "should belong to talk_group" do
+    system_talk_group = build(:system_talk_group)
+    assert_respond_to system_talk_group, :talk_group
+  end
+
+  test "system association should be configured" do
+    association = SystemTalkGroup.reflect_on_association(:system)
+    assert_not_nil association, "system association should exist"
+    assert_equal :belongs_to, association.macro
+  end
+
+  test "talk_group association should be configured" do
+    association = SystemTalkGroup.reflect_on_association(:talk_group)
+    assert_not_nil association, "talk_group association should exist"
+    assert_equal :belongs_to, association.macro
+  end
+end


### PR DESCRIPTION
Join table for Systems and TalkGroups with timeslot support.

## Implementation

- SystemTalkGroup model with belongs_to :system and :talk_group
- Validates uniqueness of system_id scoped to [talk_group_id, timeslot]
- Timeslot validation: must be 1 or 2 (DMR timeslots), or nil for non-DMR
- Database migration with unique composite index on [system_id, talk_group_id, timeslot]
- Factory with traits for timeslot_2 and no_timeslot
- 16 comprehensive model tests including timeslot validation and scoped uniqueness

## Key Features

### Timeslot Support
- DMR systems have 2 timeslots per frequency
- Same talkgroup can be on different timeslots on same system
- Timeslot can be nil for non-DMR systems (P25, analog)

### Scoped Uniqueness
- Unique combination of [system_id, talk_group_id, timeslot]
- Same system+talkgroup can exist with different timeslots
- Database-level unique index enforces constraint

## Test Results
✅ 302 tests passing (16 new)
✅ 632 assertions
✅ RuboCop clean (94 files, 0 offenses)
✅ Brakeman clean (0 security warnings)

Closes #13