### PR TITLE
Implement Channel model (issue #16)

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -1,0 +1,17 @@
+class Channel < ApplicationRecord
+  # Constants for enums
+  TONE_MODES = [ "none", "tx_only", "rx_only", "tx_rx" ].freeze
+  TRANSMIT_PERMISSIONS = [ "allow", "forbid_tx" ].freeze
+
+  # Associations
+  belongs_to :codeplug
+  belongs_to :system
+  belongs_to :system_talk_group, optional: true
+  has_many :channel_zones, dependent: :destroy
+  has_many :zones, through: :channel_zones
+
+  # Validations
+  validates :name, presence: true
+  validates :tone_mode, inclusion: { in: TONE_MODES, message: "'%{value}' is not a valid tone_mode" }
+  validates :transmit_permission, inclusion: { in: TRANSMIT_PERMISSIONS, message: "'%{value}' is not a valid transmit_permission" }
+end

--- a/db/migrate/20251103013430_create_channels.rb
+++ b/db/migrate/20251103013430_create_channels.rb
@@ -1,0 +1,18 @@
+class CreateChannels < ActiveRecord::Migration[8.1]
+  def change
+    create_table :channels do |t|
+      t.references :codeplug, null: false, foreign_key: true
+      t.references :system, null: false, foreign_key: true
+      t.references :system_talk_group, null: true, foreign_key: true
+      t.string :name, null: false
+      t.string :long_name
+      t.string :short_name
+      t.string :power_level
+      t.string :bandwidth
+      t.string :tone_mode, default: "none", null: false
+      t.string :transmit_permission, default: "allow", null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_03_010759) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_03_013430) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "analog_mode_details", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "channels", force: :cascade do |t|
+    t.string "bandwidth"
+    t.bigint "codeplug_id", null: false
+    t.datetime "created_at", null: false
+    t.string "long_name"
+    t.string "name", null: false
+    t.string "power_level"
+    t.string "short_name"
+    t.bigint "system_id", null: false
+    t.bigint "system_talk_group_id"
+    t.string "tone_mode", default: "none", null: false
+    t.string "transmit_permission", default: "allow", null: false
+    t.datetime "updated_at", null: false
+    t.index ["codeplug_id"], name: "index_channels_on_codeplug_id"
+    t.index ["system_id"], name: "index_channels_on_system_id"
+    t.index ["system_talk_group_id"], name: "index_channels_on_system_talk_group_id"
   end
 
   create_table "codeplug_layouts", force: :cascade do |t|
@@ -165,6 +183,9 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_03_010759) do
     t.index ["codeplug_id"], name: "index_zones_on_codeplug_id"
   end
 
+  add_foreign_key "channels", "codeplugs"
+  add_foreign_key "channels", "system_talk_groups"
+  add_foreign_key "channels", "systems"
   add_foreign_key "codeplug_layouts", "radio_models"
   add_foreign_key "codeplug_layouts", "users"
   add_foreign_key "codeplugs", "users"

--- a/test/factories/channels.rb
+++ b/test/factories/channels.rb
@@ -1,0 +1,38 @@
+FactoryBot.define do
+  factory :channel do
+    association :codeplug
+    association :system
+    name { Faker::Lorem.words(number: 2).join(" ").titleize }
+    long_name { Faker::Lorem.words(number: 4).join(" ").titleize }
+    short_name { Faker::Alphanumeric.alpha(number: 4).upcase }
+    power_level { [ "High", "Medium", "Low" ].sample }
+    bandwidth { [ "12.5kHz", "25kHz" ].sample }
+    tone_mode { "none" }
+    transmit_permission { "allow" }
+
+    # Trait for digital channel with talkgroup
+    trait :digital do
+      after(:build) do |channel|
+        dmr_system = create(:system, :dmr)
+        talkgroup = create(:talk_group)
+        system_talkgroup = create(:system_talk_group, system: dmr_system, talk_group: talkgroup, timeslot: 1)
+        channel.system = dmr_system
+        channel.system_talk_group = system_talkgroup
+      end
+    end
+
+    # Trait for analog channel
+    trait :analog do
+      after(:build) do |channel|
+        analog_system = create(:system, :analog)
+        channel.system = analog_system
+        channel.system_talk_group = nil
+      end
+    end
+
+    # Trait for transmit forbidden
+    trait :no_transmit do
+      transmit_permission { "forbid_tx" }
+    end
+  end
+end

--- a/test/models/channel_test.rb
+++ b/test/models/channel_test.rb
@@ -1,0 +1,212 @@
+require "test_helper"
+
+class ChannelTest < ActiveSupport::TestCase
+  # Basic Validation Tests
+  test "should save channel with valid attributes" do
+    channel = build(:channel)
+    assert channel.save, "Failed to save channel with valid attributes"
+  end
+
+  test "should not save channel without codeplug" do
+    channel = build(:channel, codeplug: nil)
+    assert_not channel.save, "Saved channel without codeplug"
+    assert_includes channel.errors[:codeplug], "must exist"
+  end
+
+  test "should not save channel without system" do
+    channel = build(:channel, system: nil)
+    assert_not channel.save, "Saved channel without system"
+    assert_includes channel.errors[:system], "must exist"
+  end
+
+  test "should not save channel without name" do
+    channel = build(:channel, name: nil)
+    assert_not channel.save, "Saved channel without name"
+    assert_includes channel.errors[:name], "can't be blank"
+  end
+
+  # Optional Attribute Tests
+  test "should save channel without system_talk_group" do
+    channel = build(:channel, system_talk_group: nil)
+    assert channel.save, "Failed to save channel without system_talk_group"
+  end
+
+  test "should save channel without long_name" do
+    channel = build(:channel, long_name: nil)
+    assert channel.save, "Failed to save channel without long_name"
+  end
+
+  test "should save channel without short_name" do
+    channel = build(:channel, short_name: nil)
+    assert channel.save, "Failed to save channel without short_name"
+  end
+
+  test "should save channel without bandwidth" do
+    channel = build(:channel, bandwidth: nil)
+    assert channel.save, "Failed to save channel without bandwidth"
+  end
+
+  # Association Tests
+  test "should belong to codeplug" do
+    channel = build(:channel)
+    assert_respond_to channel, :codeplug
+  end
+
+  test "codeplug association should be configured" do
+    association = Channel.reflect_on_association(:codeplug)
+    assert_not_nil association, "codeplug association should exist"
+    assert_equal :belongs_to, association.macro
+  end
+
+  test "should belong to system" do
+    channel = build(:channel)
+    assert_respond_to channel, :system
+  end
+
+  test "system association should be configured" do
+    association = Channel.reflect_on_association(:system)
+    assert_not_nil association, "system association should exist"
+    assert_equal :belongs_to, association.macro
+  end
+
+  test "should belong to system_talk_group optionally" do
+    channel = build(:channel)
+    assert_respond_to channel, :system_talk_group
+  end
+
+  test "system_talk_group association should be configured as optional" do
+    association = Channel.reflect_on_association(:system_talk_group)
+    assert_not_nil association, "system_talk_group association should exist"
+    assert_equal :belongs_to, association.macro
+    assert association.options[:optional], "system_talk_group should be optional"
+  end
+
+  test "should have many channel_zones" do
+    channel = create(:channel)
+    assert_respond_to channel, :channel_zones
+  end
+
+  test "channel_zones association should be configured with dependent destroy" do
+    association = Channel.reflect_on_association(:channel_zones)
+    assert_not_nil association, "channel_zones association should exist"
+    assert_equal :has_many, association.macro
+    assert_equal :destroy, association.options[:dependent]
+  end
+
+  test "should have many zones through channel_zones" do
+    channel = create(:channel)
+    assert_respond_to channel, :zones
+  end
+
+  test "zones association should be configured as through" do
+    association = Channel.reflect_on_association(:zones)
+    assert_not_nil association, "zones association should exist"
+    assert_equal :has_many, association.macro
+    assert_equal :channel_zones, association.options[:through]
+  end
+
+  # Enum Tests - tone_mode
+  test "should accept valid tone_mode values" do
+    [ "none", "tx_only", "rx_only", "tx_rx" ].each do |mode|
+      channel = build(:channel, tone_mode: mode)
+      assert channel.save, "Failed to save channel with tone_mode: #{mode}"
+    end
+  end
+
+  test "should not accept invalid tone_mode values" do
+    channel = build(:channel, tone_mode: "invalid")
+    assert_not channel.save, "Saved channel with invalid tone_mode"
+    assert_includes channel.errors[:tone_mode], "'invalid' is not a valid tone_mode"
+  end
+
+  test "should default tone_mode to none" do
+    channel = build(:channel)
+    channel.save
+    assert_equal "none", channel.tone_mode
+  end
+
+  # Enum Tests - transmit_permission
+  test "should accept valid transmit_permission values" do
+    [ "allow", "forbid_tx" ].each do |permission|
+      channel = build(:channel, transmit_permission: permission)
+      assert channel.save, "Failed to save channel with transmit_permission: #{permission}"
+    end
+  end
+
+  test "should not accept invalid transmit_permission values" do
+    channel = build(:channel, transmit_permission: "invalid")
+    assert_not channel.save, "Saved channel with invalid transmit_permission"
+    assert_includes channel.errors[:transmit_permission], "'invalid' is not a valid transmit_permission"
+  end
+
+  test "should default transmit_permission to allow" do
+    channel = build(:channel)
+    channel.save
+    assert_equal "allow", channel.transmit_permission
+  end
+
+  # Attribute Storage Tests
+  test "should store name" do
+    channel = create(:channel, name: "Repeater 1")
+    assert_equal "Repeater 1", channel.name
+  end
+
+  test "should store long_name" do
+    channel = create(:channel, long_name: "Local Repeater Channel 1")
+    assert_equal "Local Repeater Channel 1", channel.long_name
+  end
+
+  test "should store short_name" do
+    channel = create(:channel, short_name: "RPT1")
+    assert_equal "RPT1", channel.short_name
+  end
+
+  test "should store power_level" do
+    channel = create(:channel, power_level: "High")
+    assert_equal "High", channel.power_level
+  end
+
+  test "should store bandwidth" do
+    channel = create(:channel, bandwidth: "25kHz")
+    assert_equal "25kHz", channel.bandwidth
+  end
+
+  # Multiple Channels per Codeplug
+  test "codeplug can have multiple channels" do
+    codeplug = create(:codeplug)
+    channel1 = create(:channel, codeplug: codeplug, name: "Channel 1")
+    channel2 = create(:channel, codeplug: codeplug, name: "Channel 2")
+
+    assert_equal 2, codeplug.channels.count
+    assert_includes codeplug.channels, channel1
+    assert_includes codeplug.channels, channel2
+  end
+
+  # Same name in different codeplugs
+  test "different codeplugs can have channels with same name" do
+    codeplug1 = create(:codeplug)
+    codeplug2 = create(:codeplug)
+    channel1 = create(:channel, codeplug: codeplug1, name: "Repeater")
+    channel2 = create(:channel, codeplug: codeplug2, name: "Repeater")
+
+    assert channel1.persisted?
+    assert channel2.persisted?
+  end
+
+  # System TalkGroup Tests
+  test "should save digital channel with system_talk_group" do
+    dmr_system = create(:system)  # Default is DMR
+    talkgroup = create(:talk_group)
+    system_talk_group = create(:system_talk_group, system: dmr_system, talk_group: talkgroup, timeslot: 1)
+    channel = build(:channel, system: dmr_system, system_talk_group: system_talk_group)
+
+    assert channel.save, "Failed to save digital channel with system_talk_group"
+  end
+
+  test "should save analog channel without system_talk_group" do
+    analog_system = create(:system, :analog)
+    channel = build(:channel, system: analog_system, system_talk_group: nil)
+
+    assert channel.save, "Failed to save analog channel without system_talk_group"
+  end
+end


### PR DESCRIPTION
## Summary
- Implements Channel model for user's configuration to access a System
- Adds associations to codeplug, system, and system_talk_group
- Includes name validation and enum validations for tone_mode and transmit_permission
- Supports optional system_talk_group for digital modes
- 33 comprehensive tests (all passing)

## Changes
- **Model**: `app/models/channel.rb` - Channel model with associations, enums, and validations
- **Migration**: `db/migrate/20251103013430_create_channels.rb` - Database table with indexes
- **Factory**: `test/factories/channels.rb` - Factory with digital, analog, and no_transmit traits
- **Tests**: `test/models/channel_test.rb` - 33 tests covering validations, associations, enums, attributes

## Test Results
- ✅ All 374 tests passing
- ✅ RuboCop clean (106 files)
- ✅ Brakeman clean (no security warnings)

## Database Schema
```ruby
create_table :channels do |t|
  t.references :codeplug, null: false, foreign_key: true
  t.references :system, null: false, foreign_key: true
  t.references :system_talk_group, null: true, foreign_key: true
  t.string :name, null: false
  t.string :long_name
  t.string :short_name
  t.string :power_level
  t.string :bandwidth
  t.string :tone_mode, default: "none", null: false
  t.string :transmit_permission, default: "allow", null: false
  t.timestamps
end
```

## Technical Notes
- Channel inherits system data (frequencies, tones) and adds user preferences
- system_talk_group optional for analog, required for digital modes
- tone_mode enum: "none", "tx_only", "rx_only", "tx_rx"
- transmit_permission enum: "allow", "forbid_tx"
- Through association with zones via channel_zones join table
- Supports long_name and short_name for radio compatibility

## Unblocked Issues
- #17 (ChannelZone join table) - Now ready

## Test plan
- [x] Model validations tested
- [x] Associations tested (belongs_to, has_many, through)
- [x] Enum validations tested (tone_mode, transmit_permission)
- [x] Dependent destroy configured
- [x] Optional system_talk_group tested
- [x] Digital and analog channel scenarios tested
- [x] All tests pass
- [x] RuboCop clean
- [x] Brakeman clean

Resolves #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)