### PR TITLE
Implement ChannelZone join table (issue #17)

### DIFF
--- a/app/models/channel_zone.rb
+++ b/app/models/channel_zone.rb
@@ -1,0 +1,10 @@
+class ChannelZone < ApplicationRecord
+  # Associations
+  belongs_to :channel
+  belongs_to :zone
+
+  # Validations
+  validates :position, presence: true
+  validates :position, numericality: { only_integer: true, greater_than: 0 }
+  validates :position, uniqueness: { scope: :zone_id }
+end

--- a/db/migrate/20251103015043_create_channel_zones.rb
+++ b/db/migrate/20251103015043_create_channel_zones.rb
@@ -1,0 +1,13 @@
+class CreateChannelZones < ActiveRecord::Migration[8.1]
+  def change
+    create_table :channel_zones do |t|
+      t.references :channel, null: false, foreign_key: true
+      t.references :zone, null: false, foreign_key: true
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+
+    add_index :channel_zones, [ :zone_id, :position ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_03_013430) do
+ActiveRecord::Schema[8.1].define(version: 2025_11_03_015043) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "analog_mode_details", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "channel_zones", force: :cascade do |t|
+    t.bigint "channel_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "position", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "zone_id", null: false
+    t.index ["channel_id"], name: "index_channel_zones_on_channel_id"
+    t.index ["zone_id", "position"], name: "index_channel_zones_on_zone_id_and_position", unique: true
+    t.index ["zone_id"], name: "index_channel_zones_on_zone_id"
   end
 
   create_table "channels", force: :cascade do |t|
@@ -183,6 +194,8 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_03_013430) do
     t.index ["codeplug_id"], name: "index_zones_on_codeplug_id"
   end
 
+  add_foreign_key "channel_zones", "channels"
+  add_foreign_key "channel_zones", "zones"
   add_foreign_key "channels", "codeplugs"
   add_foreign_key "channels", "system_talk_groups"
   add_foreign_key "channels", "systems"

--- a/test/factories/channel_zones.rb
+++ b/test/factories/channel_zones.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :channel_zone do
+    association :channel
+    association :zone
+    sequence(:position) { |n| n }
+  end
+end

--- a/test/models/channel_zone_test.rb
+++ b/test/models/channel_zone_test.rb
@@ -1,0 +1,185 @@
+require "test_helper"
+
+class ChannelZoneTest < ActiveSupport::TestCase
+  # Basic Validation Tests
+  test "should save channel_zone with valid attributes" do
+    channel_zone = build(:channel_zone)
+    assert channel_zone.save, "Failed to save channel_zone with valid attributes"
+  end
+
+  test "should not save channel_zone without channel" do
+    channel_zone = build(:channel_zone, channel: nil)
+    assert_not channel_zone.save, "Saved channel_zone without channel"
+    assert_includes channel_zone.errors[:channel], "must exist"
+  end
+
+  test "should not save channel_zone without zone" do
+    channel_zone = build(:channel_zone, zone: nil)
+    assert_not channel_zone.save, "Saved channel_zone without zone"
+    assert_includes channel_zone.errors[:zone], "must exist"
+  end
+
+  test "should not save channel_zone without position" do
+    channel_zone = build(:channel_zone, position: nil)
+    assert_not channel_zone.save, "Saved channel_zone without position"
+    assert_includes channel_zone.errors[:position], "can't be blank"
+  end
+
+  # Association Tests
+  test "should belong to channel" do
+    channel_zone = build(:channel_zone)
+    assert_respond_to channel_zone, :channel
+  end
+
+  test "channel association should be configured" do
+    association = ChannelZone.reflect_on_association(:channel)
+    assert_not_nil association, "channel association should exist"
+    assert_equal :belongs_to, association.macro
+  end
+
+  test "should belong to zone" do
+    channel_zone = build(:channel_zone)
+    assert_respond_to channel_zone, :zone
+  end
+
+  test "zone association should be configured" do
+    association = ChannelZone.reflect_on_association(:zone)
+    assert_not_nil association, "zone association should exist"
+    assert_equal :belongs_to, association.macro
+  end
+
+  # Position Validation Tests
+  test "should save channel_zone with position 1" do
+    channel_zone = build(:channel_zone, position: 1)
+    assert channel_zone.save, "Failed to save channel_zone with position 1"
+  end
+
+  test "should save channel_zone with large position" do
+    channel_zone = build(:channel_zone, position: 1000)
+    assert channel_zone.save, "Failed to save channel_zone with large position"
+  end
+
+  test "should not save channel_zone with position 0" do
+    channel_zone = build(:channel_zone, position: 0)
+    assert_not channel_zone.save, "Saved channel_zone with position 0"
+    assert_includes channel_zone.errors[:position], "must be greater than 0"
+  end
+
+  test "should not save channel_zone with negative position" do
+    channel_zone = build(:channel_zone, position: -1)
+    assert_not channel_zone.save, "Saved channel_zone with negative position"
+    assert_includes channel_zone.errors[:position], "must be greater than 0"
+  end
+
+  # Uniqueness Tests
+  test "should not save channel_zone with duplicate position in same zone" do
+    zone = create(:zone)
+    channel1 = create(:channel)
+    create(:channel_zone, zone: zone, channel: channel1, position: 1)
+
+    channel2 = create(:channel)
+    duplicate = build(:channel_zone, zone: zone, channel: channel2, position: 1)
+    assert_not duplicate.save, "Saved channel_zone with duplicate position in same zone"
+    assert_includes duplicate.errors[:position], "has already been taken"
+  end
+
+  test "should save channel_zone with same position in different zones" do
+    zone1 = create(:zone)
+    zone2 = create(:zone)
+    channel1 = create(:channel)
+    channel2 = create(:channel)
+
+    cz1 = create(:channel_zone, zone: zone1, channel: channel1, position: 1)
+    cz2 = build(:channel_zone, zone: zone2, channel: channel2, position: 1)
+
+    assert cz2.save, "Failed to save channel_zone with same position in different zone"
+  end
+
+  test "should save same channel at different positions in same zone" do
+    zone = create(:zone)
+    channel = create(:channel)
+
+    cz1 = create(:channel_zone, zone: zone, channel: channel, position: 1)
+    cz2 = build(:channel_zone, zone: zone, channel: channel, position: 2)
+
+    assert cz2.save, "Failed to save same channel at different positions in same zone"
+  end
+
+  test "should save same channel at same position in different zones" do
+    zone1 = create(:zone)
+    zone2 = create(:zone)
+    channel = create(:channel)
+
+    cz1 = create(:channel_zone, zone: zone1, channel: channel, position: 1)
+    cz2 = build(:channel_zone, zone: zone2, channel: channel, position: 1)
+
+    assert cz2.save, "Failed to save same channel at same position in different zones"
+  end
+
+  # Position Storage Tests
+  test "should store position as integer" do
+    channel_zone = create(:channel_zone, position: 42)
+    assert_equal 42, channel_zone.position
+  end
+
+  # Multiple ChannelZones per Zone
+  test "zone can have multiple channel_zones at different positions" do
+    zone = create(:zone)
+    channel1 = create(:channel)
+    channel2 = create(:channel)
+    channel3 = create(:channel)
+
+    cz1 = create(:channel_zone, zone: zone, channel: channel1, position: 1)
+    cz2 = create(:channel_zone, zone: zone, channel: channel2, position: 2)
+    cz3 = create(:channel_zone, zone: zone, channel: channel3, position: 3)
+
+    assert_equal 3, zone.channel_zones.count
+    assert_includes zone.channel_zones, cz1
+    assert_includes zone.channel_zones, cz2
+    assert_includes zone.channel_zones, cz3
+  end
+
+  # Multiple ChannelZones per Channel
+  test "channel can have multiple channel_zones in different zones" do
+    channel = create(:channel)
+    zone1 = create(:zone)
+    zone2 = create(:zone)
+    zone3 = create(:zone)
+
+    cz1 = create(:channel_zone, channel: channel, zone: zone1, position: 1)
+    cz2 = create(:channel_zone, channel: channel, zone: zone2, position: 5)
+    cz3 = create(:channel_zone, channel: channel, zone: zone3, position: 10)
+
+    assert_equal 3, channel.channel_zones.count
+    assert_includes channel.channel_zones, cz1
+    assert_includes channel.channel_zones, cz2
+    assert_includes channel.channel_zones, cz3
+  end
+
+  # Through Association Tests
+  test "zone should have channels through channel_zones" do
+    zone = create(:zone)
+    channel1 = create(:channel)
+    channel2 = create(:channel)
+
+    create(:channel_zone, zone: zone, channel: channel1, position: 1)
+    create(:channel_zone, zone: zone, channel: channel2, position: 2)
+
+    assert_equal 2, zone.channels.count
+    assert_includes zone.channels, channel1
+    assert_includes zone.channels, channel2
+  end
+
+  test "channel should have zones through channel_zones" do
+    channel = create(:channel)
+    zone1 = create(:zone)
+    zone2 = create(:zone)
+
+    create(:channel_zone, channel: channel, zone: zone1, position: 1)
+    create(:channel_zone, channel: channel, zone: zone2, position: 1)
+
+    assert_equal 2, channel.zones.count
+    assert_includes channel.zones, zone1
+    assert_includes channel.zones, zone2
+  end
+end


### PR DESCRIPTION
## Summary
- Implements ChannelZone join table for associating Channels with Zones
- Adds position tracking for ordering channels within zones
- Includes validations for position (positive integer, unique within zone)
- Completes Phase 6 of Epic #18 - All core user configuration models now implemented
- 21 comprehensive tests (all passing)

## Changes
- **Model**: `app/models/channel_zone.rb` - Join table model with position validations
- **Migration**: `db/migrate/20251103015043_create_channel_zones.rb` - Database table with unique index
- **Factory**: `test/factories/channel_zones.rb` - Factory with sequenced position
- **Tests**: `test/models/channel_zone_test.rb` - 21 tests covering validations, associations, position logic

## Test Results
- ✅ All 395 tests passing
- ✅ RuboCop clean (110 files)
- ✅ Brakeman clean (no security warnings)

## Database Schema
```ruby
create_table :channel_zones do |t|
  t.references :channel, null: false, foreign_key: true
  t.references :zone, null: false, foreign_key: true
  t.integer :position, null: false
  t.timestamps
end

add_index :channel_zones, [:zone_id, :position], unique: true
```

## Technical Notes
- Position is 1-based (not 0-based) for user-friendly channel numbering
- Position must be unique within a zone (enforced at DB and model level)
- Same channel can appear at different positions in different zones
- Enables drag-and-drop reordering functionality (future UI feature)
- Completes the Channel ↔ Zone many-to-many relationship

## Epic Progress
**Phase 6 Complete!** All core user configuration models implemented:
- ✅ #14 - Codeplug model
- ✅ #15 - Zone model
- ✅ #16 - Channel model
- ✅ #17 - ChannelZone join table

## Test plan
- [x] Model validations tested
- [x] Associations tested (belongs_to)
- [x] Position presence validated
- [x] Position numericality validated (positive integer)
- [x] Position uniqueness within zone validated
- [x] Same channel at different positions in same zone tested
- [x] Same channel at same position in different zones tested
- [x] Through associations tested (zone.channels, channel.zones)
- [x] All tests pass
- [x] RuboCop clean
- [x] Brakeman clean

Resolves #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)