### PR TITLE
Improve Channel form dropdown text for better UX

### DIFF
--- a/app/views/channels/_form.html.erb
+++ b/app/views/channels/_form.html.erb
@@ -71,7 +71,13 @@
   <div class="row">
     <div class="col-md-6 mb-3">
       <%= f.label :tone_mode, class: "form-label" %>
-      <%= f.select :tone_mode, Channel::TONE_MODES,
+      <%= f.select :tone_mode,
+          [
+            ["None", "none"],
+            ["TX Only (Encode)", "tx_only"],
+            ["RX Only (Decode)", "rx_only"],
+            ["TX/RX (Encode & Decode)", "tx_rx"]
+          ],
           { prompt: "Select tone mode" },
           { class: "form-select", required: true } %>
       <div class="form-text">CTCSS/DCS tone usage</div>
@@ -79,7 +85,11 @@
 
     <div class="col-md-6 mb-3">
       <%= f.label :transmit_permission, class: "form-label" %>
-      <%= f.select :transmit_permission, Channel::TRANSMIT_PERMISSIONS,
+      <%= f.select :transmit_permission,
+          [
+            ["RX/TX", "allow"],
+            ["RX Only", "forbid_tx"]
+          ],
           { prompt: "Select permission" },
           { class: "form-select", required: true } %>
       <div class="form-text">Allow or forbid transmission</div>


### PR DESCRIPTION
## Summary
Updated Channel form dropdowns to display user-friendly text instead of raw enum values, improving UX for radio operators.

## Changes

### Tone Mode Dropdown
Changed from raw enum values to descriptive text:
- `none` → **"None"**
- `tx_only` → **"TX Only (Encode)"**
- `rx_only` → **"RX Only (Decode)"**
- `tx_rx` → **"TX/RX (Encode & Decode)"**

### Transmit Permission Dropdown
Changed from abbreviated values to clear, concise text:
- `allow` → **"RX/TX"**
- `forbid_tx` → **"RX Only"**

## Implementation

**File changed**: `app/views/channels/_form.html.erb`

Changed from using constants directly:
```ruby
f.select :tone_mode, Channel::TONE_MODES
```

To using array of arrays with [display_text, value] pairs:
```ruby
f.select :tone_mode, [
  ["None", "none"],
  ["TX Only (Encode)", "tx_only"],
  ["RX Only (Decode)", "rx_only"],
  ["TX/RX (Encode & Decode)", "tx_rx"]
]
```

Same approach for transmit permission dropdown.

## Backend Impact
- ✅ **No database changes** - enum values remain unchanged
- ✅ **No model changes** - Channel::TONE_MODES and Channel::TRANSMIT_PERMISSIONS constants unchanged
- ✅ **Existing data compatible** - all existing channel records work correctly
- ✅ **Validation unchanged** - form validates against the same enum values

## User Experience
**Before**:
- Tone mode options: none, tx_only, rx_only, tx_rx
- Transmit permission: allow, forbid_tx

**After**:
- Tone mode options: None, TX Only (Encode), RX Only (Decode), TX/RX (Encode & Decode)
- Transmit permission: RX/TX, RX Only

Much clearer for radio operators who may not be familiar with the internal naming conventions.

## Test Results
- ✅ **398 tests passing** (0 failures, 0 errors, 3 skips)
- ✅ **RuboCop**: No offenses detected
- ✅ **Brakeman**: No security warnings

## Notes
- Display text follows radio operator terminology (TX/RX, Encode/Decode)
- Chosen option 1 for tone mode (includes Encode/Decode terminology)
- Chosen option 2 for transmit permission (concise RX/TX format)
- No JavaScript changes needed - pure server-side rendering

## Closes
- Closes #76