### PR TITLE
Implement Zone views with full CRUD and Codeplug integration

### DIFF
--- a/app/controllers/zones_controller.rb
+++ b/app/controllers/zones_controller.rb
@@ -1,0 +1,64 @@
+class ZonesController < ApplicationController
+  before_action :set_codeplug
+  before_action :authorize_codeplug
+  before_action :set_zone, only: [ :show, :edit, :update, :destroy ]
+
+  def index
+    @zones = @codeplug.zones.order(:name)
+  end
+
+  def show
+    # Display zone details
+  end
+
+  def new
+    @zone = @codeplug.zones.new
+  end
+
+  def edit
+    # Edit zone form
+  end
+
+  def create
+    @zone = @codeplug.zones.new(zone_params)
+
+    if @zone.save
+      redirect_to codeplug_zone_path(@codeplug, @zone), notice: "Zone was successfully created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @zone.update(zone_params)
+      redirect_to codeplug_zone_path(@codeplug, @zone), notice: "Zone was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @zone.destroy!
+    redirect_to codeplug_zones_path(@codeplug), notice: "Zone was successfully deleted."
+  end
+
+  private
+
+  def set_codeplug
+    @codeplug = Codeplug.find(params[:codeplug_id])
+  end
+
+  def set_zone
+    @zone = @codeplug.zones.find(params[:id])
+  end
+
+  def authorize_codeplug
+    unless @codeplug.user == current_user
+      redirect_to codeplugs_path, alert: "You don't have permission to access this codeplug."
+    end
+  end
+
+  def zone_params
+    params.require(:zone).permit(:name, :long_name, :short_name)
+  end
+end

--- a/app/views/codeplugs/show.html.erb
+++ b/app/views/codeplugs/show.html.erb
@@ -42,6 +42,7 @@
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-center mb-3">
             <h5 class="card-title mb-0">Zones</h5>
+            <%= link_to "Manage Zones", codeplug_zones_path(@codeplug), class: "btn btn-sm btn-primary" %>
           </div>
 
           <% if @codeplug.zones.any? %>
@@ -49,7 +50,7 @@
             <ul class="list-unstyled">
               <% @codeplug.zones.limit(5).each do |zone| %>
                 <li class="mb-1">
-                  <i class="bi bi-folder"></i> <%= zone.long_name %>
+                  <i class="bi bi-folder"></i> <%= zone.long_name || zone.name %>
                   <span class="badge bg-secondary"><%= zone.channels.count %> channels</span>
                 </li>
               <% end %>

--- a/app/views/zones/_form.html.erb
+++ b/app/views/zones/_form.html.erb
@@ -1,0 +1,35 @@
+<%= form_with model: [ @codeplug, zone ] do |f| %>
+  <% if zone.errors.any? %>
+    <div class="alert alert-danger">
+      <h5><%= pluralize(zone.errors.count, "error") %> prohibited this zone from being saved:</h5>
+      <ul>
+        <% zone.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mb-3">
+    <%= f.label :name, class: "form-label" %>
+    <%= f.text_field :name, class: "form-control", required: true, placeholder: "e.g., Zone 1" %>
+    <div class="form-text">Short identifier for this zone</div>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :long_name, class: "form-label" %>
+    <%= f.text_field :long_name, class: "form-control", placeholder: "e.g., Local Repeaters" %>
+    <div class="form-text">Long descriptive name (for radios that support it)</div>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :short_name, class: "form-label" %>
+    <%= f.text_field :short_name, class: "form-control", placeholder: "e.g., LCL", maxlength: 10 %>
+    <div class="form-text">Abbreviated name (for radios with limited display)</div>
+  </div>
+
+  <div class="d-flex gap-2 mt-4">
+    <%= f.submit class: "btn btn-primary" %>
+    <%= link_to "Cancel", zone.persisted? ? codeplug_zone_path(@codeplug, zone) : codeplug_zones_path(@codeplug), class: "btn btn-secondary" %>
+  </div>
+<% end %>

--- a/app/views/zones/edit.html.erb
+++ b/app/views/zones/edit.html.erb
@@ -1,0 +1,11 @@
+<div class="container mt-4">
+  <h1>Edit Zone - <%= @zone.name %></h1>
+
+  <%= link_to "← Back to Zone", codeplug_zone_path(@codeplug, @zone), class: "btn btn-secondary mb-3" %>
+
+  <div class="card">
+    <div class="card-body">
+      <%= render "form", zone: @zone %>
+    </div>
+  </div>
+</div>

--- a/app/views/zones/index.html.erb
+++ b/app/views/zones/index.html.erb
@@ -1,0 +1,46 @@
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Zones</h1>
+    <%= link_to "New Zone", new_codeplug_zone_path(@codeplug), class: "btn btn-primary" %>
+  </div>
+
+  <%= link_to "← Back to Codeplug", codeplug_path(@codeplug), class: "btn btn-secondary mb-3" %>
+
+  <% if @zones.any? %>
+    <div class="table-responsive">
+      <table class="table table-striped table-hover">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Long Name</th>
+            <th>Short Name</th>
+            <th>Channels</th>
+            <th class="text-end">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @zones.each do |zone| %>
+            <tr>
+              <td><%= link_to zone.name, codeplug_zone_path(@codeplug, zone) %></td>
+              <td><%= zone.long_name || "—" %></td>
+              <td><%= zone.short_name || "—" %></td>
+              <td><span class="badge bg-secondary"><%= zone.channels.count %></span></td>
+              <td class="text-end text-nowrap">
+                <%= link_to "View", codeplug_zone_path(@codeplug, zone), class: "btn btn-sm btn-info me-1" %>
+                <%= link_to "Edit", edit_codeplug_zone_path(@codeplug, zone), class: "btn btn-sm btn-secondary me-1" %>
+                <%= button_to "Delete", codeplug_zone_path(@codeplug, zone), method: :delete,
+                    class: "btn btn-sm btn-danger",
+                    form: { class: "d-inline" },
+                    data: { turbo_confirm: "Are you sure?" } %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="alert alert-info">
+      No zones found. <%= link_to "Create the first one", new_codeplug_zone_path(@codeplug), class: "alert-link" %>.
+    </div>
+  <% end %>
+</div>

--- a/app/views/zones/new.html.erb
+++ b/app/views/zones/new.html.erb
@@ -1,0 +1,11 @@
+<div class="container mt-4">
+  <h1>New Zone</h1>
+
+  <%= link_to "← Back to Zones", codeplug_zones_path(@codeplug), class: "btn btn-secondary mb-3" %>
+
+  <div class="card">
+    <div class="card-body">
+      <%= render "form", zone: @zone %>
+    </div>
+  </div>
+</div>

--- a/app/views/zones/show.html.erb
+++ b/app/views/zones/show.html.erb
@@ -1,0 +1,58 @@
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1><%= @zone.name %></h1>
+    <div>
+      <%= link_to "Edit", edit_codeplug_zone_path(@codeplug, @zone), class: "btn btn-secondary me-2" %>
+      <%= button_to "Delete", codeplug_zone_path(@codeplug, @zone), method: :delete,
+          class: "btn btn-danger",
+          form: { class: "d-inline" },
+          data: { turbo_confirm: "Are you sure?" } %>
+    </div>
+  </div>
+
+  <%= link_to "← Back to Zones", codeplug_zones_path(@codeplug), class: "btn btn-secondary mb-3" %>
+
+  <div class="card mb-4">
+    <div class="card-body">
+      <h5 class="card-title">Zone Details</h5>
+
+      <div class="row mb-3">
+        <div class="col-md-4">
+          <strong>Name:</strong> <%= @zone.name %>
+        </div>
+        <div class="col-md-4">
+          <strong>Long Name:</strong> <%= @zone.long_name || "—" %>
+        </div>
+        <div class="col-md-4">
+          <strong>Short Name:</strong> <%= @zone.short_name || "—" %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title">Channels</h5>
+
+      <% if @zone.channels.any? %>
+        <p class="text-muted mb-3"><strong><%= pluralize(@zone.channels.count, "channel") %></strong></p>
+        <div class="list-group">
+          <% @zone.channels.each do |channel| %>
+            <div class="list-group-item">
+              <div class="d-flex justify-content-between align-items-center">
+                <div>
+                  <strong><%= channel.long_name %></strong>
+                  <% if channel.system %>
+                    <span class="badge bg-info ms-2"><%= channel.system.mode.upcase %></span>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="text-muted">No channels in this zone yet.</p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
 
   # Codeplugs and channels (nested)
   resources :codeplugs do
+    resources :zones
     resources :channels
   end
 

--- a/test/controllers/zones_controller_test.rb
+++ b/test/controllers/zones_controller_test.rb
@@ -1,0 +1,243 @@
+require "test_helper"
+
+class ZonesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    @other_user = create(:user)
+    @codeplug = create(:codeplug, user: @user)
+    @other_codeplug = create(:codeplug, user: @other_user)
+    @zone = create(:zone, codeplug: @codeplug, name: "Zone 1")
+    @other_zone = create(:zone, codeplug: @other_codeplug, name: "Other Zone")
+  end
+
+  # Index Action Tests
+  test "should get index for own codeplug" do
+    log_in_as(@user)
+    get codeplug_zones_path(@codeplug)
+
+    assert_response :success
+    assert_select "h1", "Zones"
+  end
+
+  test "should not get index for other user's codeplug" do
+    log_in_as(@user)
+    get codeplug_zones_path(@other_codeplug)
+
+    assert_redirected_to codeplugs_path
+    assert_equal "You don't have permission to access this codeplug.", flash[:alert]
+  end
+
+  test "should require login for index" do
+    get codeplug_zones_path(@codeplug)
+    assert_redirected_to login_path
+  end
+
+  # Show Action Tests
+  test "should show zone for own codeplug" do
+    log_in_as(@user)
+    get codeplug_zone_path(@codeplug, @zone)
+
+    assert_response :success
+    assert_select "h1", @zone.name
+  end
+
+  test "should not show zone from other user's codeplug" do
+    log_in_as(@user)
+    get codeplug_zone_path(@other_codeplug, @other_zone)
+
+    assert_redirected_to codeplugs_path
+  end
+
+  test "should require login for show" do
+    get codeplug_zone_path(@codeplug, @zone)
+    assert_redirected_to login_path
+  end
+
+  # New Action Tests
+  test "should get new for own codeplug" do
+    log_in_as(@user)
+    get new_codeplug_zone_path(@codeplug)
+
+    assert_response :success
+    assert_select "h1", "New Zone"
+  end
+
+  test "should not get new for other user's codeplug" do
+    log_in_as(@user)
+    get new_codeplug_zone_path(@other_codeplug)
+
+    assert_redirected_to codeplugs_path
+  end
+
+  test "should require login for new" do
+    get new_codeplug_zone_path(@codeplug)
+    assert_redirected_to login_path
+  end
+
+  # Create Action Tests
+  test "should create zone for own codeplug" do
+    log_in_as(@user)
+
+    assert_difference("Zone.count", 1) do
+      post codeplug_zones_path(@codeplug), params: {
+        zone: {
+          name: "New Zone",
+          long_name: "New Long Zone Name",
+          short_name: "NZN"
+        }
+      }
+    end
+
+    zone = Zone.last
+    assert_equal @codeplug, zone.codeplug
+    assert_redirected_to codeplug_zone_path(@codeplug, zone)
+    assert_equal "Zone was successfully created.", flash[:notice]
+  end
+
+  test "should not create zone without name" do
+    log_in_as(@user)
+
+    assert_no_difference("Zone.count") do
+      post codeplug_zones_path(@codeplug), params: {
+        zone: {
+          name: "",
+          long_name: "Test"
+        }
+      }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "should not create zone for other user's codeplug" do
+    log_in_as(@user)
+
+    assert_no_difference("Zone.count") do
+      post codeplug_zones_path(@other_codeplug), params: {
+        zone: {
+          name: "Hacked Zone"
+        }
+      }
+    end
+
+    assert_redirected_to codeplugs_path
+  end
+
+  test "should require login for create" do
+    assert_no_difference("Zone.count") do
+      post codeplug_zones_path(@codeplug), params: {
+        zone: {
+          name: "Test"
+        }
+      }
+    end
+
+    assert_redirected_to login_path
+  end
+
+  # Edit Action Tests
+  test "should get edit for own zone" do
+    log_in_as(@user)
+    get edit_codeplug_zone_path(@codeplug, @zone)
+
+    assert_response :success
+    assert_select "h1", text: /Edit Zone/
+  end
+
+  test "should not get edit for other user's zone" do
+    log_in_as(@user)
+    get edit_codeplug_zone_path(@other_codeplug, @other_zone)
+
+    assert_redirected_to codeplugs_path
+  end
+
+  test "should require login for edit" do
+    get edit_codeplug_zone_path(@codeplug, @zone)
+    assert_redirected_to login_path
+  end
+
+  # Update Action Tests
+  test "should update own zone" do
+    log_in_as(@user)
+
+    patch codeplug_zone_path(@codeplug, @zone), params: {
+      zone: {
+        name: "Updated Zone",
+        long_name: "Updated Long Name"
+      }
+    }
+
+    @zone.reload
+    assert_equal "Updated Zone", @zone.name
+    assert_equal "Updated Long Name", @zone.long_name
+    assert_redirected_to codeplug_zone_path(@codeplug, @zone)
+    assert_equal "Zone was successfully updated.", flash[:notice]
+  end
+
+  test "should not update without name" do
+    log_in_as(@user)
+
+    patch codeplug_zone_path(@codeplug, @zone), params: {
+      zone: {
+        name: ""
+      }
+    }
+
+    assert_response :unprocessable_entity
+  end
+
+  test "should not update other user's zone" do
+    log_in_as(@user)
+    original_name = @other_zone.name
+
+    patch codeplug_zone_path(@other_codeplug, @other_zone), params: {
+      zone: {
+        name: "Hacked Name"
+      }
+    }
+
+    @other_zone.reload
+    assert_equal original_name, @other_zone.name
+    assert_redirected_to codeplugs_path
+  end
+
+  test "should require login for update" do
+    patch codeplug_zone_path(@codeplug, @zone), params: {
+      zone: {
+        name: "New Name"
+      }
+    }
+
+    assert_redirected_to login_path
+  end
+
+  # Destroy Action Tests
+  test "should destroy own zone" do
+    log_in_as(@user)
+
+    assert_difference("Zone.count", -1) do
+      delete codeplug_zone_path(@codeplug, @zone)
+    end
+
+    assert_redirected_to codeplug_zones_path(@codeplug)
+    assert_equal "Zone was successfully deleted.", flash[:notice]
+  end
+
+  test "should not destroy other user's zone" do
+    log_in_as(@user)
+
+    assert_no_difference("Zone.count") do
+      delete codeplug_zone_path(@other_codeplug, @other_zone)
+    end
+
+    assert_redirected_to codeplugs_path
+  end
+
+  test "should require login for destroy" do
+    assert_no_difference("Zone.count") do
+      delete codeplug_zone_path(@codeplug, @zone)
+    end
+
+    assert_redirected_to login_path
+  end
+end

--- a/test/system/zones_test.rb
+++ b/test/system/zones_test.rb
@@ -1,0 +1,120 @@
+require "application_system_test_case"
+
+class ZonesTest < ApplicationSystemTestCase
+  test "creating a new zone" do
+    user = create(:user, email: "test@example.com", password: "password123")
+    codeplug = create(:codeplug, user: user, name: "Test Codeplug")
+
+    visit codeplug_path(codeplug)
+    fill_in "Email", with: "test@example.com"
+    fill_in "Password", with: "password123"
+    click_button "Log In"
+
+    click_link "Manage Zones"
+    click_link "New Zone"
+
+    fill_in "Name", with: "Zone 1"
+    fill_in "Long name", with: "Local Repeaters"
+    fill_in "Short name", with: "LCL"
+    click_button "Create Zone"
+
+    assert_text "Zone was successfully created"
+    assert_text "Zone 1"
+    assert_text "Local Repeaters"
+    assert_text "LCL"
+  end
+
+  test "editing a zone" do
+    user = create(:user, email: "test@example.com", password: "password123")
+    codeplug = create(:codeplug, user: user, name: "Test Codeplug")
+    zone = create(:zone, codeplug: codeplug, name: "Original Zone")
+
+    visit codeplug_zones_path(codeplug)
+    fill_in "Email", with: "test@example.com"
+    fill_in "Password", with: "password123"
+    click_button "Log In"
+
+    click_link "Edit", match: :first
+
+    fill_in "Name", with: "Updated Zone"
+    fill_in "Long name", with: "Updated Long Name"
+    click_button "Update Zone"
+
+    assert_text "Zone was successfully updated"
+    assert_text "Updated Zone"
+    assert_text "Updated Long Name"
+  end
+
+  test "viewing zones index" do
+    user = create(:user, email: "test@example.com", password: "password123")
+    codeplug = create(:codeplug, user: user, name: "Test Codeplug")
+    zone1 = create(:zone, codeplug: codeplug, name: "Zone 1", long_name: "Zone One")
+    zone2 = create(:zone, codeplug: codeplug, name: "Zone 2", long_name: "Zone Two")
+
+    visit codeplug_zones_path(codeplug)
+    fill_in "Email", with: "test@example.com"
+    fill_in "Password", with: "password123"
+    click_button "Log In"
+
+    assert_text "Zone 1"
+    assert_text "Zone 2"
+    assert_text "Zone One"
+    assert_text "Zone Two"
+  end
+
+  test "viewing zone details" do
+    user = create(:user, email: "test@example.com", password: "password123")
+    codeplug = create(:codeplug, user: user, name: "Test Codeplug")
+    zone = create(:zone, codeplug: codeplug, name: "Test Zone", long_name: "Test Long Name")
+
+    visit codeplug_zone_path(codeplug, zone)
+    fill_in "Email", with: "test@example.com"
+    fill_in "Password", with: "password123"
+    click_button "Log In"
+
+    assert_text "Test Zone"
+    assert_text "Test Long Name"
+  end
+
+  test "empty state shows helpful message" do
+    user = create(:user, email: "test@example.com", password: "password123")
+    codeplug = create(:codeplug, user: user, name: "Test Codeplug")
+
+    visit codeplug_zones_path(codeplug)
+    fill_in "Email", with: "test@example.com"
+    fill_in "Password", with: "password123"
+    click_button "Log In"
+
+    assert_text "No zones found"
+    assert_link "Create the first one"
+  end
+
+  test "manage zones link from codeplug show page" do
+    user = create(:user, email: "test@example.com", password: "password123")
+    codeplug = create(:codeplug, user: user, name: "Test Codeplug")
+
+    visit codeplug_path(codeplug)
+    fill_in "Email", with: "test@example.com"
+    fill_in "Password", with: "password123"
+    click_button "Log In"
+
+    click_link "Manage Zones"
+
+    assert_current_path codeplug_zones_path(codeplug)
+    assert_text "Zones"
+  end
+
+  test "cannot access other user's zones" do
+    user = create(:user, email: "test@example.com", password: "password123")
+    other_user = create(:user)
+    other_codeplug = create(:codeplug, user: other_user, name: "Other Codeplug")
+
+    visit codeplug_zones_path(other_codeplug)
+    fill_in "Email", with: "test@example.com"
+    fill_in "Password", with: "password123"
+    click_button "Log In"
+
+    assert_text "You don't have permission to access this codeplug"
+    assert_current_path codeplugs_path
+  end
+end


### PR DESCRIPTION
## Summary

Implements comprehensive Zone management interface nested under Codeplugs with full CRUD operations, user authorization, and integration into the Codeplug show page.

Closes #31

### Key Features
- **Full CRUD for Zones** - Index, show, new, create, edit, update, destroy
- **Nested Routes** - Zones managed within codeplug context
- **User Authorization** - Only codeplug owner can manage zones
- **Codeplug Integration** - "Manage Zones" button and improved summary display
- **Channel Display** - Shows channels associated with each zone

---

## Implementation Details

### Routes
Zones are nested under codeplugs:
```ruby
resources :codeplugs do
  resources :zones
  resources :channels
end
```

**Generated routes:**
- `GET /codeplugs/:codeplug_id/zones` - Index
- `GET /codeplugs/:codeplug_id/zones/:id` - Show
- `GET /codeplugs/:codeplug_id/zones/new` - New
- `POST /codeplugs/:codeplug_id/zones` - Create
- `GET /codeplugs/:codeplug_id/zones/:id/edit` - Edit
- `PATCH /codeplugs/:codeplug_id/zones/:id` - Update
- `DELETE /codeplugs/:codeplug_id/zones/:id` - Destroy

### Authorization
```ruby
before_action :authorize_codeplug

def authorize_codeplug
  unless @codeplug.user == current_user
    redirect_to codeplugs_path, alert: "You don't have permission..."
  end
end
```

Ensures only the codeplug owner can:
- View zones
- Create/edit/delete zones
- Access zone management interface

---

## Views Implemented

### Index (`/codeplugs/:id/zones`)
- **Table view** with zone details
- Displays: name, long_name, short_name, channel count
- Actions: View, Edit, Delete (with confirmation)
- "New Zone" button
- Empty state with helpful message

### Show (`/codeplugs/:id/zones/:id`)
- **Zone details card** - name, long_name, short_name
- **Channels list** - displays all channels in zone
- Channel details: name, system mode badge
- Empty state: "No channels in this zone yet"
- Edit and Delete buttons

### New/Edit
- **Shared form partial** (`_form.html.erb`)
- Fields:
  - Name (required) - Short identifier
  - Long Name (optional) - For radios supporting long names
  - Short Name (optional) - For radios with limited display
- Helper text for each field
- Cancel button returns to appropriate page

---

## Codeplug Integration

### Enhanced Zones Summary
Updated `app/views/codeplugs/show.html.erb`:

**Before:**
- Zones listed with no interaction
- No link to manage zones

**After:**
- **"Manage Zones" button** - Direct link to zones index
- **Improved display** - Shows `long_name || name` (fallback)
- **Consistent styling** - Matches channels card

---

## Files Created

**Controller:**
- `app/controllers/zones_controller.rb`
  - Full RESTful actions
  - Authorization via `authorize_codeplug`
  - User-scoped queries

**Views:**
- `app/views/zones/index.html.erb` - Zones table
- `app/views/zones/show.html.erb` - Zone details + channels
- `app/views/zones/new.html.erb` - New zone form
- `app/views/zones/edit.html.erb` - Edit zone form
- `app/views/zones/_form.html.erb` - Shared form partial

**Tests:**
- `test/controllers/zones_controller_test.rb` - 23 tests
- `test/system/zones_test.rb` - 7 tests

---

## Files Modified

**Routes:**
- `config/routes.rb` - Added `resources :zones` nested under codeplugs

**Views:**
- `app/views/codeplugs/show.html.erb`
  - Added "Manage Zones" button
  - Updated zone display to use `long_name || name`

---

## Tests Added

### Controller Tests (23 tests)
**File:** `test/controllers/zones_controller_test.rb`

**Index Action (3 tests):**
- Get index for own codeplug
- Reject access to other user's codeplug
- Require login

**Show Action (3 tests):**
- Show zone for own codeplug
- Reject access to other user's zones
- Require login

**New Action (3 tests):**
- Get new for own codeplug
- Reject access for other user's codeplug
- Require login

**Create Action (4 tests):**
- Create zone with valid attributes
- Reject creation without name
- Reject creation for other user's codeplug
- Require login

**Edit Action (3 tests):**
- Get edit for own zone
- Reject access to other user's zones
- Require login

**Update Action (4 tests):**
- Update own zone successfully
- Reject update without name
- Reject update of other user's zones
- Require login

**Destroy Action (3 tests):**
- Destroy own zone
- Reject destruction of other user's zones
- Require login

### System Tests (7 tests)
**File:** `test/system/zones_test.rb`

**Workflows:**
- Creating a new zone (full form workflow)
- Editing a zone
- Viewing zones index
- Viewing zone details
- Empty state message
- "Manage Zones" link from codeplug show page
- Authorization (cannot access other user's zones)

---

## Test Results

```bash
bin/rails test:all      # 479 tests pass (30 new)
bundle exec rubocop -a  # No offenses
bundle exec brakeman    # No security warnings
```

**Summary:**
- ✅ 479 tests pass (30 new tests)
- ✅ 23 controller tests
- ✅ 7 system tests
- ✅ RuboCop clean
- ✅ Brakeman clean

---

## Manual Testing

### CRUD Operations
- [x] Create new zone with name, long_name, short_name
- [x] View zones index with table
- [x] View individual zone details
- [x] Edit zone and update fields
- [x] Delete zone with confirmation

### Authorization
- [x] User can only access their own codeplug's zones
- [x] Attempting to access other user's zones redirects with error
- [x] Logged out users redirect to login

### Integration
- [x] "Manage Zones" button appears on codeplug show page
- [x] Button navigates to zones index
- [x] Zone summary displays correctly on codeplug page

### Empty States
- [x] "No zones found" message with "Create first one" link
- [x] "No channels in this zone yet" message on zone show

---

## Screenshots

### Zones Index
- Table with name, long_name, short_name, channel count
- Action buttons: View, Edit, Delete
- "New Zone" button in header

### Zone Show Page
- Zone details card
- Channels list with mode badges
- Edit and Delete buttons

### Zone Form
- Name field (required)
- Long name field (optional)
- Short name field (optional)
- Helper text for each field

---

## Related Issues

**Depends on:**
- #15 - Zone model ✅ Closed

**Part of:**
- Epic #18 - Phase 6

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)