### PR TITLE
Add channel ordering and zone management features

### DIFF
--- a/app/controllers/channel_zones_controller.rb
+++ b/app/controllers/channel_zones_controller.rb
@@ -1,0 +1,59 @@
+class ChannelZonesController < ApplicationController
+  before_action :set_codeplug
+  before_action :set_zone
+  before_action :authorize_codeplug
+  before_action :set_channel_zone, only: [ :destroy ]
+
+  def create
+    @channel = @codeplug.channels.find_by(id: channel_zone_params[:channel_id])
+
+    unless @channel
+      flash[:alert] = "Channel not found in this codeplug."
+      redirect_to codeplug_zone_path(@codeplug, @zone), status: :unprocessable_entity
+      return
+    end
+
+    # Get the next available position
+    max_position = @zone.channel_zones.maximum(:position) || 0
+    @channel_zone = @zone.channel_zones.new(
+      channel: @channel,
+      position: max_position + 1
+    )
+
+    if @channel_zone.save
+      redirect_to codeplug_zone_path(@codeplug, @zone), notice: "Channel was successfully added to zone."
+    else
+      flash[:alert] = @channel_zone.errors.full_messages.join(", ")
+      redirect_to codeplug_zone_path(@codeplug, @zone), status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @channel_zone.destroy!
+    redirect_to codeplug_zone_path(@codeplug, @zone), notice: "Channel was successfully removed from zone."
+  end
+
+  private
+
+  def set_codeplug
+    @codeplug = Codeplug.find(params[:codeplug_id])
+  end
+
+  def set_zone
+    @zone = @codeplug.zones.find(params[:zone_id])
+  end
+
+  def set_channel_zone
+    @channel_zone = @zone.channel_zones.find(params[:id])
+  end
+
+  def authorize_codeplug
+    unless @codeplug.user == current_user
+      redirect_to codeplugs_path, alert: "You don't have permission to access this codeplug."
+    end
+  end
+
+  def channel_zone_params
+    params.require(:channel_zone).permit(:channel_id)
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import SortableController from "./sortable_controller"
+application.register("sortable", SortableController)

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -1,0 +1,44 @@
+import { Controller } from "@hotwired/stimulus"
+import Sortable from "sortablejs"
+
+// Connects to data-controller="sortable"
+export default class extends Controller {
+  static values = {
+    url: String
+  }
+
+  connect() {
+    this.sortable = Sortable.create(this.element, {
+      animation: 150,
+      handle: ".drag-handle",
+      onEnd: this.end.bind(this)
+    })
+  }
+
+  end(event) {
+    const id = event.item.dataset.id
+    const position = event.newIndex + 1 // Convert to 1-based position
+
+    // Get all items and create positions array
+    const items = Array.from(this.element.children).map((child, index) => ({
+      id: child.dataset.id,
+      position: index + 1
+    }))
+
+    // Send update to server
+    fetch(this.urlValue, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": document.querySelector("[name='csrf-token']").content
+      },
+      body: JSON.stringify({ positions: items })
+    })
+  }
+
+  disconnect() {
+    if (this.sortable) {
+      this.sortable.destroy()
+    }
+  }
+}

--- a/app/models/channel_zone.rb
+++ b/app/models/channel_zone.rb
@@ -7,4 +7,5 @@ class ChannelZone < ApplicationRecord
   validates :position, presence: true
   validates :position, numericality: { only_integer: true, greater_than: 0 }
   validates :position, uniqueness: { scope: :zone_id }
+  validates :channel_id, uniqueness: { scope: :zone_id, message: "is already in this zone" }
 end

--- a/app/views/zones/show.html.erb
+++ b/app/views/zones/show.html.erb
@@ -32,26 +32,62 @@
 
   <div class="card">
     <div class="card-body">
-      <h5 class="card-title">Channels</h5>
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h5 class="card-title mb-0">Channels</h5>
+      </div>
 
-      <% if @zone.channels.any? %>
-        <p class="text-muted mb-3"><strong><%= pluralize(@zone.channels.count, "channel") %></strong></p>
-        <div class="list-group">
-          <% @zone.channels.each do |channel| %>
-            <div class="list-group-item">
+      <% if @available_channels.any? %>
+        <div class="card mb-3 bg-light">
+          <div class="card-body">
+            <%= form_with(model: @zone.channel_zones.new, url: codeplug_zone_channel_zones_path(@codeplug, @zone), method: :post, local: true, class: "row g-3") do |f| %>
+              <div class="col-auto flex-grow-1">
+                <%= f.select :channel_id,
+                    options_from_collection_for_select(@available_channels, :id, :long_name),
+                    { prompt: "Select a channel to add..." },
+                    { class: "form-select" } %>
+              </div>
+              <div class="col-auto">
+                <%= f.submit "Add Channel", class: "btn btn-primary" %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
+      <% if @zone.channel_zones.any? %>
+        <p class="text-muted mb-3"><strong><%= pluralize(@zone.channel_zones.count, "channel") %></strong></p>
+        <div class="list-group"
+             data-controller="sortable"
+             data-sortable-url-value="<%= update_positions_codeplug_zone_path(@codeplug, @zone) %>">
+          <% @zone.channel_zones.order(:position).each do |channel_zone| %>
+            <div class="list-group-item" data-id="<%= channel_zone.id %>">
               <div class="d-flex justify-content-between align-items-center">
-                <div>
-                  <strong><%= channel.long_name %></strong>
-                  <% if channel.system %>
-                    <span class="badge bg-info ms-2"><%= channel.system.mode.upcase %></span>
-                  <% end %>
+                <div class="d-flex align-items-center flex-grow-1">
+                  <span class="drag-handle me-3" style="cursor: grab;">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-grip-vertical" viewBox="0 0 16 16">
+                      <path d="M7 2a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM7 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM7 8a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-3 3a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-3 3a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
+                    </svg>
+                  </span>
+                  <div class="flex-grow-1">
+                    <strong><%= channel_zone.channel.long_name %></strong>
+                    <% if channel_zone.channel.system %>
+                      <span class="badge bg-info ms-2"><%= channel_zone.channel.system.mode.upcase %></span>
+                    <% end %>
+                  </div>
+                  <span class="badge bg-secondary me-2"><%= channel_zone.position %></span>
+                  <%= link_to "Edit", edit_codeplug_channel_path(@codeplug, channel_zone.channel), class: "btn btn-sm btn-outline-secondary me-2" %>
+                  <%= button_to "Remove", codeplug_zone_channel_zone_path(@codeplug, @zone, channel_zone),
+                      method: :delete,
+                      class: "btn btn-sm btn-outline-danger",
+                      form: { class: "d-inline" },
+                      data: { turbo_confirm: "Remove this channel from the zone?" } %>
                 </div>
               </div>
             </div>
           <% end %>
         </div>
       <% else %>
-        <p class="text-muted">No channels in this zone yet.</p>
+        <p class="text-muted">No channels in this zone yet. <%= "Add channels using the form above." if @available_channels.any? %></p>
       <% end %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,12 @@ Rails.application.routes.draw do
 
   # Codeplugs and channels (nested)
   resources :codeplugs do
-    resources :zones
+    resources :zones do
+      resources :channel_zones, only: [ :create, :destroy ]
+      member do
+        patch :update_positions
+      end
+    end
     resources :channels
   end
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "nodemon": "^3.1.10",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",
-    "sass": "1.77.2"
+    "sass": "1.77.2",
+    "sortablejs": "^1.15.6"
   },
   "browserslist": [
     "defaults"

--- a/test/controllers/channel_zones_controller_test.rb
+++ b/test/controllers/channel_zones_controller_test.rb
@@ -1,0 +1,143 @@
+require "test_helper"
+
+class ChannelZonesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    @other_user = create(:user)
+    @codeplug = create(:codeplug, user: @user)
+    @other_codeplug = create(:codeplug, user: @other_user)
+    @zone = create(:zone, codeplug: @codeplug, name: "Zone 1")
+    @other_zone = create(:zone, codeplug: @other_codeplug, name: "Other Zone")
+    @system = create(:system)
+    @channel = create(:channel, codeplug: @codeplug, system: @system, long_name: "Channel 1")
+    @other_channel = create(:channel, codeplug: @other_codeplug, system: @system, long_name: "Other Channel")
+  end
+
+  # Create Action Tests
+  test "should add channel to own zone" do
+    log_in_as(@user)
+
+    assert_difference("ChannelZone.count", 1) do
+      post codeplug_zone_channel_zones_path(@codeplug, @zone), params: {
+        channel_zone: {
+          channel_id: @channel.id
+        }
+      }
+    end
+
+    channel_zone = ChannelZone.last
+    assert_equal @zone, channel_zone.zone
+    assert_equal @channel, channel_zone.channel
+    assert_equal 1, channel_zone.position
+    assert_redirected_to codeplug_zone_path(@codeplug, @zone)
+    assert_equal "Channel was successfully added to zone.", flash[:notice]
+  end
+
+  test "should set correct position when adding channel to zone with existing channels" do
+    log_in_as(@user)
+    channel2 = create(:channel, codeplug: @codeplug, system: @system, long_name: "Channel 2")
+    channel3 = create(:channel, codeplug: @codeplug, system: @system, long_name: "Channel 3")
+    create(:channel_zone, zone: @zone, channel: @channel, position: 1)
+    create(:channel_zone, zone: @zone, channel: channel2, position: 2)
+
+    assert_difference("ChannelZone.count", 1) do
+      post codeplug_zone_channel_zones_path(@codeplug, @zone), params: {
+        channel_zone: {
+          channel_id: channel3.id
+        }
+      }
+    end
+
+    channel_zone = ChannelZone.last
+    assert_equal 3, channel_zone.position
+  end
+
+  test "should not add channel from other user's codeplug to zone" do
+    log_in_as(@user)
+
+    assert_no_difference("ChannelZone.count") do
+      post codeplug_zone_channel_zones_path(@codeplug, @zone), params: {
+        channel_zone: {
+          channel_id: @other_channel.id
+        }
+      }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "should not add duplicate channel to zone" do
+    log_in_as(@user)
+    create(:channel_zone, zone: @zone, channel: @channel, position: 1)
+
+    assert_no_difference("ChannelZone.count") do
+      post codeplug_zone_channel_zones_path(@codeplug, @zone), params: {
+        channel_zone: {
+          channel_id: @channel.id
+        }
+      }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  test "should not add channel to other user's zone" do
+    log_in_as(@user)
+
+    assert_no_difference("ChannelZone.count") do
+      post codeplug_zone_channel_zones_path(@other_codeplug, @other_zone), params: {
+        channel_zone: {
+          channel_id: @channel.id
+        }
+      }
+    end
+
+    assert_redirected_to codeplugs_path
+  end
+
+  test "should require login for create" do
+    assert_no_difference("ChannelZone.count") do
+      post codeplug_zone_channel_zones_path(@codeplug, @zone), params: {
+        channel_zone: {
+          channel_id: @channel.id
+        }
+      }
+    end
+
+    assert_redirected_to login_path
+  end
+
+  # Destroy Action Tests
+  test "should remove channel from own zone" do
+    log_in_as(@user)
+    channel_zone = create(:channel_zone, zone: @zone, channel: @channel, position: 1)
+
+    assert_difference("ChannelZone.count", -1) do
+      delete codeplug_zone_channel_zone_path(@codeplug, @zone, channel_zone)
+    end
+
+    assert_redirected_to codeplug_zone_path(@codeplug, @zone)
+    assert_equal "Channel was successfully removed from zone.", flash[:notice]
+  end
+
+  test "should not remove channel from other user's zone" do
+    log_in_as(@user)
+    other_channel_zone = create(:channel_zone, zone: @other_zone, channel: @other_channel, position: 1)
+
+    assert_no_difference("ChannelZone.count") do
+      delete codeplug_zone_channel_zone_path(@other_codeplug, @other_zone, other_channel_zone)
+    end
+
+    assert_redirected_to codeplugs_path
+  end
+
+  test "should require login for destroy" do
+    channel_zone = create(:channel_zone, zone: @zone, channel: @channel, position: 1)
+
+    assert_no_difference("ChannelZone.count") do
+      delete codeplug_zone_channel_zone_path(@codeplug, @zone, channel_zone)
+    end
+
+    assert_redirected_to login_path
+  end
+end

--- a/test/models/channel_zone_test.rb
+++ b/test/models/channel_zone_test.rb
@@ -95,14 +95,15 @@ class ChannelZoneTest < ActiveSupport::TestCase
     assert cz2.save, "Failed to save channel_zone with same position in different zone"
   end
 
-  test "should save same channel at different positions in same zone" do
+  test "should not save duplicate channel in same zone" do
     zone = create(:zone)
     channel = create(:channel)
 
     cz1 = create(:channel_zone, zone: zone, channel: channel, position: 1)
     cz2 = build(:channel_zone, zone: zone, channel: channel, position: 2)
 
-    assert cz2.save, "Failed to save same channel at different positions in same zone"
+    assert_not cz2.save, "Should not allow same channel in zone twice"
+    assert_includes cz2.errors[:channel_id], "is already in this zone"
   end
 
   test "should save same channel at same position in different zones" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -624,6 +624,11 @@ slash@^5.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-5.1.0.tgz#be3adddcdf09ac38eebe8dcdc7b1a57a75b095ce"
   integrity sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==
 
+sortablejs@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.15.6.tgz#ff93699493f5b8ab8d828f933227b4988df1d393"
+  integrity sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==
+
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"


### PR DESCRIPTION
## Summary
Implements drag-and-drop channel reordering within zones and adds comprehensive zone management capabilities for Issue #33.

## Features Added
- **Drag-and-drop reordering**: Users can reorder channels within zones using SortableJS library
- **Add channels to zones**: Dropdown form to add existing channels from the codeplug to a zone
- **Remove channels from zones**: Remove button with confirmation dialog
- **Edit channels**: Quick access to edit channel details from zone view
- **Position management**: Automatic position assignment and two-pass update to avoid conflicts

## Technical Implementation
- Created Stimulus controller (`sortable_controller.js`) for drag-drop functionality
- Added `ChannelZonesController` for managing channel-zone associations (create/destroy)
- Added `update_positions` action to `ZonesController` with two-pass update strategy
- Added uniqueness validation to prevent duplicate channels in zones
- Enhanced zone show page with interactive UI (drag handles, add form, remove/edit buttons)

## Testing
- ✅ All 495 tests passing (13 new tests added)
- ✅ Rubocop clean
- ✅ Brakeman clean

## Files Changed
- 13 files changed, 494 insertions(+), 19 deletions(-)
- 3 new files created

🤖 Generated with [Claude Code](https://claude.com/claude-code)