### PR TITLE
Implement standalone Zones index and show pages (Issue #95)

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -41,6 +41,9 @@
             <%= link_to "Systems", systems_path, class: "nav-link #{request.path.start_with?('/systems') ? 'active' : ''}" %>
           </li>
           <li class="nav-item">
+            <%= link_to "Zones", zones_path, class: "nav-link #{request.path.start_with?('/zones') && !request.path.include?('/codeplugs/') ? 'active' : ''}" %>
+          </li>
+          <li class="nav-item">
             <%= link_to "Codeplugs", codeplugs_path, class: "nav-link #{request.path.start_with?('/codeplugs') ? 'active' : ''}" %>
           </li>
         <% end %>

--- a/app/views/zones/_form.html.erb
+++ b/app/views/zones/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: [ @codeplug, zone ] do |f| %>
+<%= form_with model: @codeplug ? [ @codeplug, zone ] : zone do |f| %>
   <% if zone.errors.any? %>
     <div class="alert alert-danger">
       <h5><%= pluralize(zone.errors.count, "error") %> prohibited this zone from being saved:</h5>
@@ -28,8 +28,22 @@
     <div class="form-text">Abbreviated name (for radios with limited display)</div>
   </div>
 
+  <% unless @codeplug %>
+    <div class="mb-3">
+      <div class="form-check">
+        <%= f.check_box :public, class: "form-check-input" %>
+        <%= f.label :public, "Make this zone public", class: "form-check-label" %>
+        <div class="form-text">Public zones can be viewed by all users. Private zones are only visible to you.</div>
+      </div>
+    </div>
+  <% end %>
+
   <div class="d-flex gap-2 mt-4">
     <%= f.submit class: "btn btn-primary" %>
-    <%= link_to "Cancel", zone.persisted? ? codeplug_zone_path(@codeplug, zone) : codeplug_zones_path(@codeplug), class: "btn btn-secondary" %>
+    <% if @codeplug %>
+      <%= link_to "Cancel", zone.persisted? ? codeplug_zone_path(@codeplug, zone) : codeplug_zones_path(@codeplug), class: "btn btn-secondary" %>
+    <% else %>
+      <%= link_to "Cancel", zone.persisted? ? zone_path(zone) : zones_path, class: "btn btn-secondary" %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/zones/edit.html.erb
+++ b/app/views/zones/edit.html.erb
@@ -1,7 +1,11 @@
 <div class="container mt-4">
   <h1>Edit Zone - <%= @zone.name %></h1>
 
-  <%= link_to "← Back to Zone", codeplug_zone_path(@codeplug, @zone), class: "btn btn-secondary mb-3" %>
+  <% if @codeplug %>
+    <%= link_to "← Back to Zone", codeplug_zone_path(@codeplug, @zone), class: "btn btn-secondary mb-3" %>
+  <% else %>
+    <%= link_to "← Back to Zone", zone_path(@zone), class: "btn btn-secondary mb-3" %>
+  <% end %>
 
   <div class="card">
     <div class="card-body">

--- a/app/views/zones/index.html.erb
+++ b/app/views/zones/index.html.erb
@@ -1,10 +1,16 @@
 <div class="container mt-4">
   <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>Zones</h1>
-    <%= link_to "New Zone", new_codeplug_zone_path(@codeplug), class: "btn btn-primary" %>
+    <% if @codeplug %>
+      <%= link_to "New Zone", new_codeplug_zone_path(@codeplug), class: "btn btn-primary" %>
+    <% else %>
+      <%= link_to "New Zone", new_zone_path, class: "btn btn-primary" %>
+    <% end %>
   </div>
 
-  <%= link_to "← Back to Codeplug", codeplug_path(@codeplug), class: "btn btn-secondary mb-3" %>
+  <% if @codeplug %>
+    <%= link_to "← Back to Codeplug", codeplug_path(@codeplug), class: "btn btn-secondary mb-3" %>
+  <% end %>
 
   <% if @zones.any? %>
     <div class="table-responsive">
@@ -14,24 +20,63 @@
             <th>Name</th>
             <th>Long Name</th>
             <th>Short Name</th>
-            <th>Channels</th>
+            <% unless @codeplug %>
+              <th>Owner</th>
+              <th>Visibility</th>
+              <th>Systems</th>
+            <% else %>
+              <th>Channels</th>
+            <% end %>
             <th class="text-end">Actions</th>
           </tr>
         </thead>
         <tbody>
           <% @zones.each do |zone| %>
             <tr>
-              <td><%= link_to zone.name, codeplug_zone_path(@codeplug, zone) %></td>
+              <% if @codeplug %>
+                <td><%= link_to zone.name, codeplug_zone_path(@codeplug, zone) %></td>
+              <% else %>
+                <td><%= link_to zone.name, zone_path(zone) %></td>
+              <% end %>
               <td><%= zone.long_name || "—" %></td>
               <td><%= zone.short_name || "—" %></td>
-              <td><span class="badge bg-secondary"><%= zone.channels.count %></span></td>
+              <% if @codeplug %>
+                <td><span class="badge bg-secondary"><%= zone.channels.count %></span></td>
+              <% else %>
+                <td>
+                  <% if zone.user == current_user %>
+                    <span class="text-muted">You</span>
+                  <% else %>
+                    <%= zone.user.email %>
+                  <% end %>
+                </td>
+                <td>
+                  <% if zone.public? %>
+                    <span class="badge bg-success">Public</span>
+                  <% else %>
+                    <span class="badge bg-secondary">Private</span>
+                  <% end %>
+                </td>
+                <td><span class="badge bg-info"><%= zone.zone_systems.count %></span></td>
+              <% end %>
               <td class="text-end text-nowrap">
-                <%= link_to "View", codeplug_zone_path(@codeplug, zone), class: "btn btn-sm btn-info me-1" %>
-                <%= link_to "Edit", edit_codeplug_zone_path(@codeplug, zone), class: "btn btn-sm btn-secondary me-1" %>
-                <%= button_to "Delete", codeplug_zone_path(@codeplug, zone), method: :delete,
-                    class: "btn btn-sm btn-danger",
-                    form: { class: "d-inline" },
-                    data: { turbo_confirm: "Are you sure?" } %>
+                <% if @codeplug %>
+                  <%= link_to "View", codeplug_zone_path(@codeplug, zone), class: "btn btn-sm btn-info me-1" %>
+                  <%= link_to "Edit", edit_codeplug_zone_path(@codeplug, zone), class: "btn btn-sm btn-secondary me-1" %>
+                  <%= button_to "Delete", codeplug_zone_path(@codeplug, zone), method: :delete,
+                      class: "btn btn-sm btn-danger",
+                      form: { class: "d-inline" },
+                      data: { turbo_confirm: "Are you sure?" } %>
+                <% else %>
+                  <%= link_to "View", zone_path(zone), class: "btn btn-sm btn-info me-1" %>
+                  <% if zone.editable_by?(current_user) %>
+                    <%= link_to "Edit", edit_zone_path(zone), class: "btn btn-sm btn-secondary me-1" %>
+                    <%= button_to "Delete", zone_path(zone), method: :delete,
+                        class: "btn btn-sm btn-danger",
+                        form: { class: "d-inline" },
+                        data: { turbo_confirm: "Are you sure?" } %>
+                  <% end %>
+                <% end %>
               </td>
             </tr>
           <% end %>
@@ -40,7 +85,11 @@
     </div>
   <% else %>
     <div class="alert alert-info">
-      No zones found. <%= link_to "Create the first one", new_codeplug_zone_path(@codeplug), class: "alert-link" %>.
+      <% if @codeplug %>
+        No zones found. <%= link_to "Create the first one", new_codeplug_zone_path(@codeplug), class: "alert-link" %>.
+      <% else %>
+        No zones found. <%= link_to "Create the first one", new_zone_path, class: "alert-link" %>.
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/zones/new.html.erb
+++ b/app/views/zones/new.html.erb
@@ -1,7 +1,11 @@
 <div class="container mt-4">
   <h1>New Zone</h1>
 
-  <%= link_to "← Back to Zones", codeplug_zones_path(@codeplug), class: "btn btn-secondary mb-3" %>
+  <% if @codeplug %>
+    <%= link_to "← Back to Zones", codeplug_zones_path(@codeplug), class: "btn btn-secondary mb-3" %>
+  <% else %>
+    <%= link_to "← Back to Zones", zones_path, class: "btn btn-secondary mb-3" %>
+  <% end %>
 
   <div class="card">
     <div class="card-body">

--- a/app/views/zones/show.html.erb
+++ b/app/views/zones/show.html.erb
@@ -2,15 +2,27 @@
   <div class="d-flex justify-content-between align-items-center mb-4">
     <h1><%= @zone.name %></h1>
     <div>
-      <%= link_to "Edit", edit_codeplug_zone_path(@codeplug, @zone), class: "btn btn-secondary me-2" %>
-      <%= button_to "Delete", codeplug_zone_path(@codeplug, @zone), method: :delete,
-          class: "btn btn-danger",
-          form: { class: "d-inline" },
-          data: { turbo_confirm: "Are you sure?" } %>
+      <% if @codeplug %>
+        <%= link_to "Edit", edit_codeplug_zone_path(@codeplug, @zone), class: "btn btn-secondary me-2" %>
+        <%= button_to "Delete", codeplug_zone_path(@codeplug, @zone), method: :delete,
+            class: "btn btn-danger",
+            form: { class: "d-inline" },
+            data: { turbo_confirm: "Are you sure?" } %>
+      <% elsif @zone.editable_by?(current_user) %>
+        <%= link_to "Edit", edit_zone_path(@zone), class: "btn btn-secondary me-2" %>
+        <%= button_to "Delete", zone_path(@zone), method: :delete,
+            class: "btn btn-danger",
+            form: { class: "d-inline" },
+            data: { turbo_confirm: "Are you sure?" } %>
+      <% end %>
     </div>
   </div>
 
-  <%= link_to "← Back to Zones", codeplug_zones_path(@codeplug), class: "btn btn-secondary mb-3" %>
+  <% if @codeplug %>
+    <%= link_to "← Back to Zones", codeplug_zones_path(@codeplug), class: "btn btn-secondary mb-3" %>
+  <% else %>
+    <%= link_to "← Back to Zones", zones_path, class: "btn btn-secondary mb-3" %>
+  <% end %>
 
   <div class="card mb-4">
     <div class="card-body">
@@ -27,68 +39,121 @@
           <strong>Short Name:</strong> <%= @zone.short_name || "—" %>
         </div>
       </div>
-    </div>
-  </div>
 
-  <div class="card">
-    <div class="card-body">
-      <div class="d-flex justify-content-between align-items-center mb-3">
-        <h5 class="card-title mb-0">Channels</h5>
-      </div>
-
-      <% if @available_channels.any? %>
-        <div class="card mb-3 bg-light">
-          <div class="card-body">
-            <%= form_with(model: @zone.channel_zones.new, url: codeplug_zone_channel_zones_path(@codeplug, @zone), method: :post, local: true, class: "row g-3") do |f| %>
-              <div class="col-auto flex-grow-1">
-                <%= f.select :channel_id,
-                    options_from_collection_for_select(@available_channels, :id, :long_name),
-                    { prompt: "Select a channel to add..." },
-                    { class: "form-select" } %>
-              </div>
-              <div class="col-auto">
-                <%= f.submit "Add Channel", class: "btn btn-primary" %>
-              </div>
+      <% unless @codeplug %>
+        <div class="row mb-3">
+          <div class="col-md-4">
+            <strong>Owner:</strong> <%= @zone.user.email %>
+          </div>
+          <div class="col-md-4">
+            <strong>Visibility:</strong>
+            <% if @zone.public? %>
+              <span class="badge bg-success">Public</span>
+            <% else %>
+              <span class="badge bg-secondary">Private</span>
             <% end %>
           </div>
         </div>
       <% end %>
-
-      <% if @zone.channel_zones.any? %>
-        <p class="text-muted mb-3"><strong><%= pluralize(@zone.channel_zones.count, "channel") %></strong></p>
-        <div class="list-group"
-             data-controller="sortable"
-             data-sortable-url-value="<%= update_positions_codeplug_zone_path(@codeplug, @zone) %>">
-          <% @zone.channel_zones.order(:position).each do |channel_zone| %>
-            <div class="list-group-item" data-id="<%= channel_zone.id %>">
-              <div class="d-flex justify-content-between align-items-center">
-                <div class="d-flex align-items-center flex-grow-1">
-                  <span class="drag-handle me-3" style="cursor: grab;">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-grip-vertical" viewBox="0 0 16 16">
-                      <path d="M7 2a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM7 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM7 8a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-3 3a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-3 3a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
-                    </svg>
-                  </span>
-                  <div class="flex-grow-1">
-                    <strong><%= channel_zone.channel.long_name %></strong>
-                    <% if channel_zone.channel.system %>
-                      <span class="badge bg-info ms-2"><%= channel_zone.channel.system.mode.upcase %></span>
-                    <% end %>
-                  </div>
-                  <span class="badge bg-secondary me-2"><%= channel_zone.position %></span>
-                  <%= link_to "Edit", edit_codeplug_channel_path(@codeplug, channel_zone.channel), class: "btn btn-sm btn-outline-secondary me-2" %>
-                  <%= button_to "Remove", codeplug_zone_channel_zone_path(@codeplug, @zone, channel_zone),
-                      method: :delete,
-                      class: "btn btn-sm btn-outline-danger",
-                      form: { class: "d-inline" },
-                      data: { turbo_confirm: "Remove this channel from the zone?" } %>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      <% else %>
-        <p class="text-muted">No channels in this zone yet. <%= "Add channels using the form above." if @available_channels.any? %></p>
-      <% end %>
     </div>
   </div>
+
+  <% if @codeplug %>
+    <div class="card">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <h5 class="card-title mb-0">Channels</h5>
+        </div>
+
+        <% if @available_channels.any? %>
+          <div class="card mb-3 bg-light">
+            <div class="card-body">
+              <%= form_with(model: @zone.channel_zones.new, url: codeplug_zone_channel_zones_path(@codeplug, @zone), method: :post, local: true, class: "row g-3") do |f| %>
+                <div class="col-auto flex-grow-1">
+                  <%= f.select :channel_id,
+                      options_from_collection_for_select(@available_channels, :id, :long_name),
+                      { prompt: "Select a channel to add..." },
+                      { class: "form-select" } %>
+                </div>
+                <div class="col-auto">
+                  <%= f.submit "Add Channel", class: "btn btn-primary" %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+
+        <% if @zone.channel_zones.any? %>
+          <p class="text-muted mb-3"><strong><%= pluralize(@zone.channel_zones.count, "channel") %></strong></p>
+          <div class="list-group"
+               data-controller="sortable"
+               data-sortable-url-value="<%= update_positions_codeplug_zone_path(@codeplug, @zone) %>">
+            <% @zone.channel_zones.order(:position).each do |channel_zone| %>
+              <div class="list-group-item" data-id="<%= channel_zone.id %>">
+                <div class="d-flex justify-content-between align-items-center">
+                  <div class="d-flex align-items-center flex-grow-1">
+                    <span class="drag-handle me-3" style="cursor: grab;">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-grip-vertical" viewBox="0 0 16 16">
+                        <path d="M7 2a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM7 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zM7 8a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-3 3a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-3 3a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm3 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
+                      </svg>
+                    </span>
+                    <div class="flex-grow-1">
+                      <strong><%= channel_zone.channel.long_name %></strong>
+                      <% if channel_zone.channel.system %>
+                        <span class="badge bg-info ms-2"><%= channel_zone.channel.system.mode.upcase %></span>
+                      <% end %>
+                    </div>
+                    <span class="badge bg-secondary me-2"><%= channel_zone.position %></span>
+                    <%= link_to "Edit", edit_codeplug_channel_path(@codeplug, channel_zone.channel), class: "btn btn-sm btn-outline-secondary me-2" %>
+                    <%= button_to "Remove", codeplug_zone_channel_zone_path(@codeplug, @zone, channel_zone),
+                        method: :delete,
+                        class: "btn btn-sm btn-outline-danger",
+                        form: { class: "d-inline" },
+                        data: { turbo_confirm: "Remove this channel from the zone?" } %>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <p class="text-muted">No channels in this zone yet. <%= "Add channels using the form above." if @available_channels.any? %></p>
+        <% end %>
+      </div>
+    </div>
+  <% else %>
+    <%# Standalone zone view - show systems %>
+    <div class="card">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <h5 class="card-title mb-0">Systems</h5>
+        </div>
+
+        <% if @zone_systems.any? %>
+          <p class="text-muted mb-3"><strong><%= pluralize(@zone_systems.count, "system") %></strong></p>
+          <div class="list-group">
+            <% @zone_systems.each do |zone_system| %>
+              <div class="list-group-item">
+                <div class="d-flex justify-content-between align-items-center">
+                  <div class="flex-grow-1">
+                    <strong><%= zone_system.system.name %></strong>
+                    <span class="badge bg-info ms-2"><%= zone_system.system.mode.upcase %></span>
+                    <br>
+                    <small class="text-muted">
+                      <%= zone_system.system.rx_frequency %> MHz
+                      <% if zone_system.system.tx_frequency != zone_system.system.rx_frequency %>
+                        / <%= zone_system.system.tx_frequency %> MHz
+                      <% end %>
+                    </small>
+                  </div>
+                  <span class="badge bg-secondary"><%= zone_system.position %></span>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <p class="text-muted">No systems in this zone yet.</p>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,8 +31,12 @@ Rails.application.routes.draw do
     resources :system_talk_groups, only: [ :create, :destroy ]
   end
 
+  # Standalone zones (new top-level resource)
+  resources :zones, only: [ :index, :show, :new, :create, :edit, :update, :destroy ]
+
   # Codeplugs and channels (nested)
   resources :codeplugs do
+    # Nested zones routes (kept for backward compatibility, will be deprecated)
     resources :zones do
       resources :channel_zones, only: [ :create, :destroy ]
       member do


### PR DESCRIPTION
## Summary

This PR implements **Issue #95: Standalone Zones index and show pages** (Phase 2 of Epic #91: Zone Architecture Refactor).

Adds top-level routes and views for zones, allowing users to browse and view public zones from other users, while maintaining full backward compatibility with the existing nested codeplug zones routes.

## Changes Made

### Routes
- ✅ Added top-level zones resources to `config/routes.rb` (index, show, new, create, edit, update, destroy)
- ✅ Maintained backward compatibility with nested codeplug zones routes

### Controller
- ✅ Updated `ZonesController` to support both nested (under codeplug) and standalone routes
- ✅ Added `nested_route?` helper method to determine context
- ✅ Implemented conditional authorization using `viewable_by?` and `editable_by?` methods
- ✅ Added standalone route filtering using `Zone.available_to_user(current_user)` scope

### Tests
- ✅ Added 13 new controller tests for standalone zones functionality
- ✅ All 542 application tests passing (0 failures, 0 errors)
- ✅ Comprehensive test coverage for authorization scenarios

### Views
- ✅ **index.html.erb**: Shows different columns for nested vs standalone (owner/visibility/systems vs channels)
- ✅ **show.html.erb**: Displays channels for codeplug context, systems for standalone context
- ✅ **_form.html.erb**: Added public checkbox for standalone zones, conditional routing
- ✅ **new.html.erb**: Conditional back button routing
- ✅ **edit.html.erb**: Conditional back button routing
- ✅ **_navbar.html.erb**: Added "Zones" link to main navigation menu

## Testing

### Test Results
```
542 runs, 1245 assertions, 0 failures, 0 errors, 3 skips
```

### Code Quality
- ✅ **Rubocop**: 136 files inspected, no offenses detected
- ✅ **Brakeman**: 0 security warnings

## Screenshots

N/A - Backend functionality

## Related Issues

- Implements: #95
- Part of Epic: #91 (Zone Architecture Refactor - Phase 2)
- Depends on: #94 (merged in PR #110)

## Backward Compatibility

This PR maintains full backward compatibility with existing nested zone routes under codeplugs. All existing functionality continues to work as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)