### PR TITLE
Add system and user-owned manufacturers and radio models

### DIFF
--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -1,5 +1,6 @@
 class Manufacturer < ApplicationRecord
   # Associations
+  belongs_to :user, optional: true
   has_many :radio_models, dependent: :restrict_with_error
 
   # Validations
@@ -8,6 +9,18 @@ class Manufacturer < ApplicationRecord
 
   # Callbacks
   before_validation :strip_whitespace
+
+  # Scopes
+  scope :system, -> { where(system_record: true) }
+  scope :user_owned, ->(user) { where(user_id: user.id) }
+  scope :visible_to, ->(user) { where(system_record: true).or(where(user_id: user.id)) }
+
+  # Authorization methods
+  def editable_by?(user)
+    return false if user.nil?
+    return false if system_record?
+    self.user == user
+  end
 
   private
 

--- a/app/models/radio_model.rb
+++ b/app/models/radio_model.rb
@@ -1,6 +1,7 @@
 class RadioModel < ApplicationRecord
   # Associations
   belongs_to :manufacturer
+  belongs_to :user, optional: true
   has_many :codeplug_layouts, dependent: :restrict_with_error
 
   # Serialization
@@ -18,6 +19,18 @@ class RadioModel < ApplicationRecord
   validates :short_channel_name_length, numericality: { greater_than: 0, allow_nil: true }
   validates :long_zone_name_length, numericality: { greater_than: 0, allow_nil: true }
   validates :short_zone_name_length, numericality: { greater_than: 0, allow_nil: true }
+
+  # Scopes
+  scope :system, -> { where(system_record: true) }
+  scope :user_owned, ->(user) { where(user_id: user.id) }
+  scope :visible_to, ->(user) { where(system_record: true).or(where(user_id: user.id)) }
+
+  # Authorization methods
+  def editable_by?(user)
+    return false if user.nil?
+    return false if system_record?
+    self.user == user
+  end
 
   private
 

--- a/app/views/manufacturers/index.html.erb
+++ b/app/views/manufacturers/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mt-4">
   <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>Manufacturers</h1>
-    <%= link_to "New Manufacturer", new_manufacturer_path, class: "btn btn-primary" %>
+    <%= link_to "Add Custom Manufacturer", new_manufacturer_path, class: "btn btn-primary" %>
   </div>
 
   <% if @manufacturers.any? %>
@@ -10,22 +10,32 @@
         <thead>
           <tr>
             <th>Name</th>
+            <th>Type</th>
             <th>Radio Models</th>
             <th class="text-end">Actions</th>
           </tr>
         </thead>
         <tbody>
           <% @manufacturers.each do |manufacturer| %>
-            <tr>
+            <tr class="<%= 'table-light' if manufacturer.system_record? %>">
               <td><%= link_to manufacturer.name, manufacturer_path(manufacturer) %></td>
+              <td>
+                <% if manufacturer.system_record? %>
+                  <span class="badge bg-secondary">System</span>
+                <% else %>
+                  <span class="badge bg-primary">Custom</span>
+                <% end %>
+              </td>
               <td><%= manufacturer.radio_models.count %></td>
               <td class="text-end">
                 <%= link_to "View", manufacturer_path(manufacturer), class: "btn btn-sm btn-info me-1" %>
-                <%= link_to "Edit", edit_manufacturer_path(manufacturer), class: "btn btn-sm btn-secondary me-1" %>
-                <%= button_to "Delete", manufacturer_path(manufacturer), method: :delete,
-                    class: "btn btn-sm btn-danger",
-                    form: { class: "d-inline" },
-                    data: { confirm: "Are you sure? This will prevent deletion if radio models exist." } %>
+                <% if manufacturer.editable_by?(current_user) %>
+                  <%= link_to "Edit", edit_manufacturer_path(manufacturer), class: "btn btn-sm btn-secondary me-1" %>
+                  <%= button_to "Delete", manufacturer_path(manufacturer), method: :delete,
+                      class: "btn btn-sm btn-danger",
+                      form: { class: "d-inline" },
+                      data: { turbo_confirm: "Are you sure? This will prevent deletion if radio models exist." } %>
+                <% end %>
               </td>
             </tr>
           <% end %>

--- a/app/views/manufacturers/show.html.erb
+++ b/app/views/manufacturers/show.html.erb
@@ -1,12 +1,23 @@
 <div class="container mt-4">
   <div class="d-flex justify-content-between align-items-center mb-4">
-    <h1><%= @manufacturer.name %></h1>
     <div>
-      <%= link_to "Edit", edit_manufacturer_path(@manufacturer), class: "btn btn-secondary me-1" %>
-      <%= button_to "Delete", manufacturer_path(@manufacturer), method: :delete,
-          class: "btn btn-danger me-1",
-          form: { class: "d-inline" },
-          data: { confirm: "Are you sure? This will prevent deletion if radio models exist." } %>
+      <h1>
+        <%= @manufacturer.name %>
+        <% if @manufacturer.system_record? %>
+          <span class="badge bg-secondary fs-6">System</span>
+        <% else %>
+          <span class="badge bg-primary fs-6">Custom</span>
+        <% end %>
+      </h1>
+    </div>
+    <div>
+      <% if @manufacturer.editable_by?(current_user) %>
+        <%= link_to "Edit", edit_manufacturer_path(@manufacturer), class: "btn btn-secondary me-1" %>
+        <%= button_to "Delete", manufacturer_path(@manufacturer), method: :delete,
+            class: "btn btn-danger me-1",
+            form: { class: "d-inline" },
+            data: { turbo_confirm: "Are you sure? This will prevent deletion if radio models exist." } %>
+      <% end %>
       <%= link_to "Back", manufacturers_path, class: "btn btn-outline-secondary" %>
     </div>
   </div>
@@ -17,6 +28,15 @@
       <dl class="row mb-0">
         <dt class="col-sm-3">Name:</dt>
         <dd class="col-sm-9"><%= @manufacturer.name %></dd>
+
+        <dt class="col-sm-3">Type:</dt>
+        <dd class="col-sm-9">
+          <% if @manufacturer.system_record? %>
+            <span class="badge bg-secondary">System (read-only)</span>
+          <% else %>
+            <span class="badge bg-primary">Custom</span>
+          <% end %>
+        </dd>
 
         <dt class="col-sm-3">Radio Models:</dt>
         <dd class="col-sm-9"><%= @manufacturer.radio_models.count %></dd>
@@ -35,6 +55,7 @@
             <thead>
               <tr>
                 <th>Model Name</th>
+                <th>Type</th>
                 <th>Supported Modes</th>
                 <th>Max Zones</th>
                 <th>Max Channels/Zone</th>
@@ -45,6 +66,13 @@
               <% @manufacturer.radio_models.order(:name).each do |radio_model| %>
                 <tr>
                   <td><%= link_to radio_model.name, radio_model_path(radio_model) %></td>
+                  <td>
+                    <% if radio_model.system_record? %>
+                      <span class="badge bg-secondary">System</span>
+                    <% else %>
+                      <span class="badge bg-primary">Custom</span>
+                    <% end %>
+                  </td>
                   <td><%= radio_model.supported_modes.join(", ") %></td>
                   <td><%= radio_model.max_zones || "Unlimited" %></td>
                   <td><%= radio_model.max_channels_per_zone || "Unlimited" %></td>

--- a/app/views/radio_models/index.html.erb
+++ b/app/views/radio_models/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mt-4">
   <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>Radio Models</h1>
-    <%= link_to "New Radio Model", new_radio_model_path, class: "btn btn-primary" %>
+    <%= link_to "Add Custom Radio Model", new_radio_model_path, class: "btn btn-primary" %>
   </div>
 
   <div class="table-responsive">
@@ -10,6 +10,7 @@
         <tr>
           <th>Manufacturer</th>
           <th>Model</th>
+          <th>Type</th>
           <th>Supported Modes</th>
           <th>Max Zones</th>
           <th>Channels/Zone</th>
@@ -18,19 +19,28 @@
       </thead>
       <tbody>
         <% @radio_models.each do |radio_model| %>
-          <tr>
+          <tr class="<%= 'table-light' if radio_model.system_record? %>">
             <td><%= radio_model.manufacturer.name %></td>
             <td><%= link_to radio_model.name, radio_model_path(radio_model) %></td>
+            <td>
+              <% if radio_model.system_record? %>
+                <span class="badge bg-secondary">System</span>
+              <% else %>
+                <span class="badge bg-primary">Custom</span>
+              <% end %>
+            </td>
             <td><%= radio_model.supported_modes.join(", ") %></td>
             <td><%= radio_model.max_zones || "Unlimited" %></td>
             <td><%= radio_model.max_channels_per_zone || "N/A" %></td>
             <td>
               <%= link_to "View", radio_model_path(radio_model), class: "btn btn-sm btn-outline-info me-1" %>
-              <%= link_to "Edit", edit_radio_model_path(radio_model), class: "btn btn-sm btn-outline-primary me-1" %>
-              <%= button_to "Delete", radio_model_path(radio_model), method: :delete,
-                  class: "btn btn-sm btn-outline-danger",
-                  form: { class: "d-inline" },
-                  data: { turbo_confirm: "Are you sure?" } %>
+              <% if radio_model.editable_by?(current_user) %>
+                <%= link_to "Edit", edit_radio_model_path(radio_model), class: "btn btn-sm btn-outline-primary me-1" %>
+                <%= button_to "Delete", radio_model_path(radio_model), method: :delete,
+                    class: "btn btn-sm btn-outline-danger",
+                    form: { class: "d-inline" },
+                    data: { turbo_confirm: "Are you sure?" } %>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/app/views/radio_models/show.html.erb
+++ b/app/views/radio_models/show.html.erb
@@ -1,15 +1,39 @@
 <div class="container mt-4">
   <div class="d-flex justify-content-between align-items-center mb-4">
-    <h1><%= @radio_model.name %></h1>
     <div>
-      <%= link_to "Edit", edit_radio_model_path(@radio_model), class: "btn btn-primary me-1" %>
+      <h1>
+        <%= @radio_model.name %>
+        <% if @radio_model.system_record? %>
+          <span class="badge bg-secondary fs-6">System</span>
+        <% else %>
+          <span class="badge bg-primary fs-6">Custom</span>
+        <% end %>
+      </h1>
+    </div>
+    <div>
+      <% if @radio_model.editable_by?(current_user) %>
+        <%= link_to "Edit", edit_radio_model_path(@radio_model), class: "btn btn-primary me-1" %>
+        <%= button_to "Delete", radio_model_path(@radio_model), method: :delete,
+            class: "btn btn-danger me-1",
+            form: { class: "d-inline" },
+            data: { turbo_confirm: "Are you sure?" } %>
+      <% end %>
       <%= link_to "Back", radio_models_path, class: "btn btn-secondary" %>
     </div>
   </div>
 
   <dl class="row">
     <dt class="col-sm-3">Manufacturer:</dt>
-    <dd class="col-sm-9"><%= @radio_model.manufacturer.name %></dd>
+    <dd class="col-sm-9"><%= link_to @radio_model.manufacturer.name, manufacturer_path(@radio_model.manufacturer) %></dd>
+
+    <dt class="col-sm-3">Type:</dt>
+    <dd class="col-sm-9">
+      <% if @radio_model.system_record? %>
+        <span class="badge bg-secondary">System (read-only)</span>
+      <% else %>
+        <span class="badge bg-primary">Custom</span>
+      <% end %>
+    </dd>
 
     <dt class="col-sm-3">Supported Modes:</dt>
     <dd class="col-sm-9"><%= @radio_model.supported_modes.join(", ") %></dd>

--- a/db/migrate/20251206035912_add_ownership_to_manufacturers.rb
+++ b/db/migrate/20251206035912_add_ownership_to_manufacturers.rb
@@ -1,0 +1,13 @@
+class AddOwnershipToManufacturers < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :manufacturers, :user, null: true, foreign_key: true
+    add_column :manufacturers, :system_record, :boolean, default: false, null: false
+
+    # Convert existing records to system records
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE manufacturers SET system_record = true"
+      end
+    end
+  end
+end

--- a/db/migrate/20251206035936_add_ownership_to_radio_models.rb
+++ b/db/migrate/20251206035936_add_ownership_to_radio_models.rb
@@ -1,0 +1,13 @@
+class AddOwnershipToRadioModels < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :radio_models, :user, null: true, foreign_key: true
+    add_column :radio_models, :system_record, :boolean, default: false, null: false
+
+    # Convert existing records to system records
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE radio_models SET system_record = true"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_11_08_040852) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_06_035936) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -91,8 +91,11 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_08_040852) do
   create_table "manufacturers", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false
+    t.boolean "system_record", default: false, null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["name"], name: "index_manufacturers_on_name", unique: true
+    t.index ["user_id"], name: "index_manufacturers_on_user_id"
   end
 
   create_table "networks", force: :cascade do |t|
@@ -123,9 +126,12 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_08_040852) do
     t.integer "short_channel_name_length"
     t.integer "short_zone_name_length"
     t.text "supported_modes", null: false
+    t.boolean "system_record", default: false, null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["manufacturer_id", "name"], name: "index_radio_models_on_manufacturer_id_and_name", unique: true
     t.index ["manufacturer_id"], name: "index_radio_models_on_manufacturer_id"
+    t.index ["user_id"], name: "index_radio_models_on_user_id"
   end
 
   create_table "system_networks", force: :cascade do |t|
@@ -242,7 +248,9 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_08_040852) do
   add_foreign_key "codeplug_zones", "codeplugs"
   add_foreign_key "codeplug_zones", "zones"
   add_foreign_key "codeplugs", "users"
+  add_foreign_key "manufacturers", "users"
   add_foreign_key "radio_models", "manufacturers"
+  add_foreign_key "radio_models", "users"
   add_foreign_key "system_networks", "networks"
   add_foreign_key "system_networks", "systems"
   add_foreign_key "system_talk_groups", "systems"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,9 +16,9 @@ if Rails.env.development?
     u.default_power_level = "medium"
     u.measurement_preference = "imperial"
   end
-  puts "✓ Created seed user: #{user.email}"
+  puts "Created seed user: #{user.email}"
 
-  # Create manufacturers
+  # Create system manufacturers (read-only, shared with all users)
   manufacturers_data = [
     "Motorola",
     "Baofeng",
@@ -33,11 +33,15 @@ if Rails.env.development?
   ]
 
   manufacturers = manufacturers_data.map do |name|
-    Manufacturer.find_or_create_by!(name: name)
+    manufacturer = Manufacturer.find_or_initialize_by(name: name)
+    manufacturer.system_record = true
+    manufacturer.user_id = nil
+    manufacturer.save!
+    manufacturer
   end
-  puts "✓ Created #{manufacturers.count} manufacturers"
+  puts "Created #{manufacturers.count} system manufacturers"
 
-  # Create radio models
+  # Create system radio models (read-only, shared with all users)
   radio_models_data = [
     # Motorola DMR radios
     {
@@ -203,18 +207,20 @@ if Rails.env.development?
 
   radio_models_data.each do |data|
     manufacturer = Manufacturer.find_by!(name: data[:manufacturer])
-    RadioModel.find_or_create_by!(manufacturer: manufacturer, name: data[:name]) do |rm|
-      rm.supported_modes = data[:supported_modes]
-      rm.max_zones = data[:max_zones]
-      rm.max_channels_per_zone = data[:max_channels_per_zone]
-      rm.long_channel_name_length = data[:long_channel_name_length]
-      rm.short_channel_name_length = data[:short_channel_name_length]
-      rm.long_zone_name_length = data[:long_zone_name_length]
-      rm.short_zone_name_length = data[:short_zone_name_length]
-      rm.frequency_ranges = data[:frequency_ranges]
-    end
+    radio_model = RadioModel.find_or_initialize_by(manufacturer: manufacturer, name: data[:name])
+    radio_model.supported_modes = data[:supported_modes]
+    radio_model.max_zones = data[:max_zones]
+    radio_model.max_channels_per_zone = data[:max_channels_per_zone]
+    radio_model.long_channel_name_length = data[:long_channel_name_length]
+    radio_model.short_channel_name_length = data[:short_channel_name_length]
+    radio_model.long_zone_name_length = data[:long_zone_name_length]
+    radio_model.short_zone_name_length = data[:short_zone_name_length]
+    radio_model.frequency_ranges = data[:frequency_ranges]
+    radio_model.system_record = true
+    radio_model.user_id = nil
+    radio_model.save!
   end
-  puts "✓ Created #{radio_models_data.count} radio models"
+  puts "Created #{radio_models_data.count} system radio models"
 
   puts "\n=== Seed data complete ==="
   puts "Login with: dev@example.com / password123"

--- a/test/controllers/manufacturers_controller_test.rb
+++ b/test/controllers/manufacturers_controller_test.rb
@@ -3,8 +3,11 @@ require "test_helper"
 class ManufacturersControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = create(:user)
+    @other_user = create(:user)
     log_in_as(@user)
-    @manufacturer = create(:manufacturer)
+    @system_manufacturer = create(:manufacturer, :system, name: "System Manufacturer")
+    @user_manufacturer = create(:manufacturer, :user_owned, user: @user, name: "User Manufacturer")
+    @other_user_manufacturer = create(:manufacturer, :user_owned, user: @other_user, name: "Other User Manufacturer")
   end
 
   # Index Tests
@@ -18,15 +21,32 @@ class ManufacturersControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", "Manufacturers"
   end
 
+  test "index shows system records and own records only" do
+    get manufacturers_path
+    assert_select "td", text: "System Manufacturer"
+    assert_select "td", text: "User Manufacturer"
+    assert_select "td", { text: "Other User Manufacturer", count: 0 }
+  end
+
   # Show Tests
-  test "should get show" do
-    get manufacturer_path(@manufacturer)
+  test "should get show for system record" do
+    get manufacturer_path(@system_manufacturer)
     assert_response :success
   end
 
+  test "should get show for own record" do
+    get manufacturer_path(@user_manufacturer)
+    assert_response :success
+  end
+
+  test "should not show other user's record" do
+    get manufacturer_path(@other_user_manufacturer)
+    assert_response :forbidden
+  end
+
   test "show should display manufacturer name" do
-    get manufacturer_path(@manufacturer)
-    assert_select "h1", @manufacturer.name
+    get manufacturer_path(@user_manufacturer)
+    assert_select "h1", text: /#{@user_manufacturer.name}/
   end
 
   # New Tests
@@ -49,7 +69,10 @@ class ManufacturersControllerTest < ActionDispatch::IntegrationTest
         }
       }
     end
-    assert_redirected_to manufacturer_path(Manufacturer.last)
+    manufacturer = Manufacturer.last
+    assert_equal @user, manufacturer.user
+    assert_not manufacturer.system_record?
+    assert_redirected_to manufacturer_path(manufacturer)
   end
 
   test "should not create manufacturer with invalid attributes" do
@@ -64,53 +87,100 @@ class ManufacturersControllerTest < ActionDispatch::IntegrationTest
   end
 
   # Edit Tests
-  test "should get edit" do
-    get edit_manufacturer_path(@manufacturer)
+  test "should get edit for own record" do
+    get edit_manufacturer_path(@user_manufacturer)
     assert_response :success
   end
 
+  test "should not get edit for system record" do
+    get edit_manufacturer_path(@system_manufacturer)
+    assert_response :forbidden
+  end
+
+  test "should not get edit for other user's record" do
+    get edit_manufacturer_path(@other_user_manufacturer)
+    assert_response :forbidden
+  end
+
   test "edit should display form with existing value" do
-    get edit_manufacturer_path(@manufacturer)
+    get edit_manufacturer_path(@user_manufacturer)
     assert_select "form"
-    assert_select "input[value=?]", @manufacturer.name
+    assert_select "input[value=?]", @user_manufacturer.name
   end
 
   # Update Tests
-  test "should update manufacturer with valid attributes" do
-    patch manufacturer_path(@manufacturer), params: {
+  test "should update own manufacturer with valid attributes" do
+    patch manufacturer_path(@user_manufacturer), params: {
       manufacturer: {
         name: "Updated Name"
       }
     }
-    assert_redirected_to manufacturer_path(@manufacturer)
-    @manufacturer.reload
-    assert_equal "Updated Name", @manufacturer.name
+    assert_redirected_to manufacturer_path(@user_manufacturer)
+    @user_manufacturer.reload
+    assert_equal "Updated Name", @user_manufacturer.name
   end
 
   test "should not update manufacturer with invalid attributes" do
-    original_name = @manufacturer.name
-    patch manufacturer_path(@manufacturer), params: {
+    original_name = @user_manufacturer.name
+    patch manufacturer_path(@user_manufacturer), params: {
       manufacturer: {
         name: ""
       }
     }
     assert_response :unprocessable_entity
-    @manufacturer.reload
-    assert_equal original_name, @manufacturer.name
+    @user_manufacturer.reload
+    assert_equal original_name, @user_manufacturer.name
+  end
+
+  test "should not update system manufacturer" do
+    original_name = @system_manufacturer.name
+    patch manufacturer_path(@system_manufacturer), params: {
+      manufacturer: {
+        name: "Hacked Name"
+      }
+    }
+    assert_response :forbidden
+    @system_manufacturer.reload
+    assert_equal original_name, @system_manufacturer.name
+  end
+
+  test "should not update other user's manufacturer" do
+    original_name = @other_user_manufacturer.name
+    patch manufacturer_path(@other_user_manufacturer), params: {
+      manufacturer: {
+        name: "Hacked Name"
+      }
+    }
+    assert_response :forbidden
+    @other_user_manufacturer.reload
+    assert_equal original_name, @other_user_manufacturer.name
   end
 
   # Destroy Tests
-  test "should destroy manufacturer" do
+  test "should destroy own manufacturer" do
     assert_difference("Manufacturer.count", -1) do
-      delete manufacturer_path(@manufacturer)
+      delete manufacturer_path(@user_manufacturer)
     end
     assert_redirected_to manufacturers_path
     assert_equal "Manufacturer was successfully deleted.", flash[:notice]
   end
 
+  test "should not destroy system manufacturer" do
+    assert_no_difference("Manufacturer.count") do
+      delete manufacturer_path(@system_manufacturer)
+    end
+    assert_response :forbidden
+  end
+
+  test "should not destroy other user's manufacturer" do
+    assert_no_difference("Manufacturer.count") do
+      delete manufacturer_path(@other_user_manufacturer)
+    end
+    assert_response :forbidden
+  end
+
   private
 
-  # Helper method to simulate user login
   def log_in_as(user)
     post login_path, params: {
       email: user.email,

--- a/test/controllers/radio_models_controller_test.rb
+++ b/test/controllers/radio_models_controller_test.rb
@@ -3,9 +3,12 @@ require "test_helper"
 class RadioModelsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = create(:user)
+    @other_user = create(:user)
     log_in_as(@user)
-    @manufacturer = create(:manufacturer)
-    @radio_model = create(:radio_model, manufacturer: @manufacturer)
+    @manufacturer = create(:manufacturer, :system)
+    @system_radio_model = create(:radio_model, :system, manufacturer: @manufacturer, name: "System Model")
+    @user_radio_model = create(:radio_model, :user_owned, user: @user, manufacturer: @manufacturer, name: "User Model")
+    @other_user_radio_model = create(:radio_model, :user_owned, user: @other_user, manufacturer: @manufacturer, name: "Other User Model")
   end
 
   # Index Tests
@@ -15,29 +18,40 @@ class RadioModelsControllerTest < ActionDispatch::IntegrationTest
     assert_select "h1", /Radio Models/i
   end
 
-  test "should display radio models on index" do
+  test "index shows system records and own records only" do
     get radio_models_path
-    assert_response :success
-    assert_select "td", text: @radio_model.name
-    assert_select "td", text: @manufacturer.name
+    assert_select "td", text: "System Model"
+    assert_select "td", text: "User Model"
+    assert_select "td", { text: "Other User Model", count: 0 }
   end
 
   # Show Tests
-  test "should show radio model" do
-    get radio_model_path(@radio_model)
+  test "should show system radio model" do
+    get radio_model_path(@system_radio_model)
     assert_response :success
-    assert_select "h1", text: @radio_model.name
+    assert_select "h1", text: /#{@system_radio_model.name}/
+  end
+
+  test "should show own radio model" do
+    get radio_model_path(@user_radio_model)
+    assert_response :success
+    assert_select "h1", text: /#{@user_radio_model.name}/
+  end
+
+  test "should not show other user's radio model" do
+    get radio_model_path(@other_user_radio_model)
+    assert_response :forbidden
   end
 
   test "should display manufacturer on show page" do
-    get radio_model_path(@radio_model)
+    get radio_model_path(@user_radio_model)
     assert_response :success
     assert_select "dt", text: /Manufacturer/i
     assert_select "dd", text: @manufacturer.name
   end
 
   test "should display supported modes on show page" do
-    get radio_model_path(@radio_model)
+    get radio_model_path(@user_radio_model)
     assert_response :success
     assert_select "dt", text: /Supported Modes/i
   end
@@ -73,7 +87,10 @@ class RadioModelsControllerTest < ActionDispatch::IntegrationTest
         }
       }
     end
-    assert_redirected_to radio_model_path(RadioModel.last)
+    radio_model = RadioModel.last
+    assert_equal @user, radio_model.user
+    assert_not radio_model.system_record?
+    assert_redirected_to radio_model_path(radio_model)
     assert_equal "Radio model was successfully created.", flash[:notice]
   end
 
@@ -102,45 +119,89 @@ class RadioModelsControllerTest < ActionDispatch::IntegrationTest
   end
 
   # Edit Tests
-  test "should get edit" do
-    get edit_radio_model_path(@radio_model)
+  test "should get edit for own record" do
+    get edit_radio_model_path(@user_radio_model)
     assert_response :success
     assert_select "h1", /Edit Radio Model/i
-    assert_select "form[action=?]", radio_model_path(@radio_model)
+    assert_select "form[action=?]", radio_model_path(@user_radio_model)
+  end
+
+  test "should not get edit for system record" do
+    get edit_radio_model_path(@system_radio_model)
+    assert_response :forbidden
+  end
+
+  test "should not get edit for other user's record" do
+    get edit_radio_model_path(@other_user_radio_model)
+    assert_response :forbidden
   end
 
   # Update Tests
-  test "should update radio model with valid data" do
-    patch radio_model_path(@radio_model), params: {
+  test "should update own radio model with valid data" do
+    patch radio_model_path(@user_radio_model), params: {
       radio_model: {
         name: "Updated Name",
         max_zones: 200
       }
     }
-    assert_redirected_to radio_model_path(@radio_model)
+    assert_redirected_to radio_model_path(@user_radio_model)
     assert_equal "Radio model was successfully updated.", flash[:notice]
 
-    @radio_model.reload
-    assert_equal "Updated Name", @radio_model.name
-    assert_equal 200, @radio_model.max_zones
+    @user_radio_model.reload
+    assert_equal "Updated Name", @user_radio_model.name
+    assert_equal 200, @user_radio_model.max_zones
   end
 
   test "should not update radio model with invalid data" do
-    patch radio_model_path(@radio_model), params: {
+    patch radio_model_path(@user_radio_model), params: {
       radio_model: { name: "" }
     }
     assert_response :unprocessable_entity
 
-    @radio_model.reload
-    assert_not_equal "", @radio_model.name
+    @user_radio_model.reload
+    assert_not_equal "", @user_radio_model.name
+  end
+
+  test "should not update system radio model" do
+    original_name = @system_radio_model.name
+    patch radio_model_path(@system_radio_model), params: {
+      radio_model: { name: "Hacked Name" }
+    }
+    assert_response :forbidden
+    @system_radio_model.reload
+    assert_equal original_name, @system_radio_model.name
+  end
+
+  test "should not update other user's radio model" do
+    original_name = @other_user_radio_model.name
+    patch radio_model_path(@other_user_radio_model), params: {
+      radio_model: { name: "Hacked Name" }
+    }
+    assert_response :forbidden
+    @other_user_radio_model.reload
+    assert_equal original_name, @other_user_radio_model.name
   end
 
   # Destroy Tests
-  test "should destroy radio model" do
+  test "should destroy own radio model" do
     assert_difference("RadioModel.count", -1) do
-      delete radio_model_path(@radio_model)
+      delete radio_model_path(@user_radio_model)
     end
     assert_redirected_to radio_models_path
     assert_equal "Radio model was successfully deleted.", flash[:notice]
+  end
+
+  test "should not destroy system radio model" do
+    assert_no_difference("RadioModel.count") do
+      delete radio_model_path(@system_radio_model)
+    end
+    assert_response :forbidden
+  end
+
+  test "should not destroy other user's radio model" do
+    assert_no_difference("RadioModel.count") do
+      delete radio_model_path(@other_user_radio_model)
+    end
+    assert_response :forbidden
   end
 end

--- a/test/factories/manufacturers.rb
+++ b/test/factories/manufacturers.rb
@@ -1,5 +1,17 @@
 FactoryBot.define do
   factory :manufacturer do
     name { Faker::Company.name }
+    system_record { false }
+    user { nil }
+
+    trait :system do
+      system_record { true }
+      user { nil }
+    end
+
+    trait :user_owned do
+      system_record { false }
+      association :user
+    end
   end
 end

--- a/test/factories/radio_models.rb
+++ b/test/factories/radio_models.rb
@@ -15,5 +15,17 @@ FactoryBot.define do
         { band: "70cm", min: 420.0, max: 450.0 }
       ]
     end
+    system_record { false }
+    user { nil }
+
+    trait :system do
+      system_record { true }
+      user { nil }
+    end
+
+    trait :user_owned do
+      system_record { false }
+      association :user
+    end
   end
 end

--- a/test/models/manufacturer_test.rb
+++ b/test/models/manufacturer_test.rb
@@ -57,4 +57,115 @@ class ManufacturerTest < ActiveSupport::TestCase
     manufacturer = create(:manufacturer, name: "  Icom  ")
     assert_equal "Icom", manufacturer.name, "Name should have whitespace trimmed"
   end
+
+  # User Association Tests
+  test "should belong to user" do
+    user = create(:user)
+    manufacturer = create(:manufacturer, :user_owned, user: user)
+    assert_equal user, manufacturer.user
+  end
+
+  test "should allow nil user for system records" do
+    manufacturer = create(:manufacturer, :system)
+    assert_nil manufacturer.user
+    assert manufacturer.system_record?
+  end
+
+  # System Record Tests
+  test "system_record defaults to false" do
+    manufacturer = build(:manufacturer)
+    assert_equal false, manufacturer.system_record
+  end
+
+  test "system records have no user" do
+    manufacturer = create(:manufacturer, :system)
+    assert manufacturer.system_record?
+    assert_nil manufacturer.user_id
+  end
+
+  test "user-owned records have user and system_record false" do
+    user = create(:user)
+    manufacturer = create(:manufacturer, :user_owned, user: user)
+    assert_not manufacturer.system_record?
+    assert_equal user, manufacturer.user
+  end
+
+  # Scope Tests
+  test "system scope returns only system records" do
+    system_manufacturer = create(:manufacturer, :system, name: "System Mfg")
+    user = create(:user)
+    user_manufacturer = create(:manufacturer, :user_owned, user: user, name: "User Mfg")
+
+    system_records = Manufacturer.system
+    assert_includes system_records, system_manufacturer
+    assert_not_includes system_records, user_manufacturer
+  end
+
+  test "user_owned scope returns records for specific user" do
+    user1 = create(:user)
+    user2 = create(:user)
+    manufacturer1 = create(:manufacturer, :user_owned, user: user1, name: "User1 Mfg")
+    manufacturer2 = create(:manufacturer, :user_owned, user: user2, name: "User2 Mfg")
+    system_manufacturer = create(:manufacturer, :system, name: "System Mfg")
+
+    user1_records = Manufacturer.user_owned(user1)
+    assert_includes user1_records, manufacturer1
+    assert_not_includes user1_records, manufacturer2
+    assert_not_includes user1_records, system_manufacturer
+  end
+
+  test "visible_to scope returns system records and user's own records" do
+    user1 = create(:user)
+    user2 = create(:user)
+    system_manufacturer = create(:manufacturer, :system, name: "System Mfg")
+    user1_manufacturer = create(:manufacturer, :user_owned, user: user1, name: "User1 Mfg")
+    user2_manufacturer = create(:manufacturer, :user_owned, user: user2, name: "User2 Mfg")
+
+    visible_to_user1 = Manufacturer.visible_to(user1)
+    assert_includes visible_to_user1, system_manufacturer
+    assert_includes visible_to_user1, user1_manufacturer
+    assert_not_includes visible_to_user1, user2_manufacturer
+  end
+
+  # Authorization Method Tests
+  test "editable_by? returns false for system records" do
+    user = create(:user)
+    manufacturer = create(:manufacturer, :system)
+    assert_not manufacturer.editable_by?(user)
+  end
+
+  test "editable_by? returns true for owner of user-owned record" do
+    user = create(:user)
+    manufacturer = create(:manufacturer, :user_owned, user: user)
+    assert manufacturer.editable_by?(user)
+  end
+
+  test "editable_by? returns false for non-owner of user-owned record" do
+    owner = create(:user)
+    other_user = create(:user)
+    manufacturer = create(:manufacturer, :user_owned, user: owner)
+    assert_not manufacturer.editable_by?(other_user)
+  end
+
+  test "editable_by? returns false when user is nil" do
+    manufacturer = create(:manufacturer, :user_owned)
+    assert_not manufacturer.editable_by?(nil)
+  end
+
+  # Uniqueness Tests
+  test "does not allow duplicate name globally" do
+    user1 = create(:user)
+    user2 = create(:user)
+    create(:manufacturer, :user_owned, user: user1, name: "Custom Radio")
+    manufacturer2 = build(:manufacturer, :user_owned, user: user2, name: "Custom Radio")
+    assert_not manufacturer2.valid?, "Should not allow duplicate names globally"
+    assert_includes manufacturer2.errors[:name], "has already been taken"
+  end
+
+  test "allows user-owned name that differs from system record name" do
+    create(:manufacturer, :system, name: "Motorola")
+    user = create(:user)
+    manufacturer = build(:manufacturer, :user_owned, user: user, name: "Motorola (Custom)")
+    assert manufacturer.valid?, "Should allow user to create custom name similar to system"
+  end
 end


### PR DESCRIPTION
## Summary

- Enable both system-level (canonical, read-only) and user-owned (custom, editable) Manufacturers and Radio Models
- System records are shared with all users and cannot be edited/deleted
- Users can create their own custom manufacturers and radio models
- UI clearly distinguishes system vs custom records with badges

## Changes

### Database
- Add `user_id` and `system_record` columns to `manufacturers` table
- Add `user_id` and `system_record` columns to `radio_models` table
- Existing records converted to system records via migration

### Models
- `Manufacturer` - Added user association, scopes (`system`, `user_owned`, `visible_to`), `editable_by?` method
- `RadioModel` - Same pattern as Manufacturer

### Controllers
- Authorization for view/edit/destroy actions
- Index filtered to show only visible records
- User automatically assigned on create

### Views
- Index pages show "System" vs "Custom" badges
- Edit/Delete buttons conditionally shown for editable records only
- Show pages display type badges

### Seeds
- Updated to create system manufacturers and radio models

## Test plan

- [x] All 597 tests pass
- [x] RuboCop: No offenses
- [x] Brakeman: No security warnings
- [ ] Manually verify system records show as read-only in UI
- [ ] Manually verify users can create/edit/delete their own custom records
- [ ] Manually verify other users' custom records are not accessible

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)