### PR TITLE
Replace bandwidth free text with dropdown picklist

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -2,6 +2,7 @@ class Channel < ApplicationRecord
   # Constants for enums
   TONE_MODES = [ "none", "tx_only", "rx_only", "tx_rx" ].freeze
   TRANSMIT_PERMISSIONS = [ "allow", "forbid_tx" ].freeze
+  BANDWIDTHS = [ "12.5 kHz", "20 kHz", "25 kHz" ].freeze
 
   # Associations
   belongs_to :codeplug

--- a/app/models/system.rb
+++ b/app/models/system.rb
@@ -1,6 +1,7 @@
 class System < ApplicationRecord
   # Constants
   MODES = [ "analog", "dmr", "p25", "nxdn" ].freeze
+  BANDWIDTHS = [ "12.5 kHz", "20 kHz", "25 kHz" ].freeze
 
   # Associations
   belongs_to :mode_detail, polymorphic: true, optional: true

--- a/app/views/channels/_form.html.erb
+++ b/app/views/channels/_form.html.erb
@@ -63,7 +63,9 @@
 
     <div class="col-md-6 mb-3">
       <%= f.label :bandwidth, class: "form-label" %>
-      <%= f.text_field :bandwidth, class: "form-control", placeholder: "e.g., 25kHz, 12.5kHz" %>
+      <%= f.select :bandwidth, Channel::BANDWIDTHS,
+          { prompt: "Select bandwidth", include_blank: true },
+          { class: "form-select" } %>
       <div class="form-text">Override system bandwidth (optional)</div>
     </div>
   </div>

--- a/app/views/systems/_form.html.erb
+++ b/app/views/systems/_form.html.erb
@@ -42,7 +42,9 @@
 
   <div class="mb-3">
     <%= f.label :bandwidth, class: "form-label" %>
-    <%= f.text_field :bandwidth, class: "form-control", placeholder: "e.g., 25kHz, 12.5kHz" %>
+    <%= f.select :bandwidth, System::BANDWIDTHS,
+        { prompt: "Select bandwidth", include_blank: true },
+        { class: "form-select" } %>
     <div class="form-text">Default bandwidth (optional)</div>
   </div>
 

--- a/test/controllers/systems_controller_test.rb
+++ b/test/controllers/systems_controller_test.rb
@@ -71,6 +71,14 @@ class SystemsControllerTest < ActionDispatch::IntegrationTest
     assert_select "form"
   end
 
+  test "new form should have bandwidth dropdown" do
+    get new_system_path
+    assert_select "select[name='system[bandwidth]']"
+    System::BANDWIDTHS.each do |bw|
+      assert_select "option[value='#{bw}']", text: bw
+    end
+  end
+
   # Create Tests - DMR
   test "should create DMR system with valid attributes" do
     assert_difference("System.count", 1) do

--- a/test/models/channel_test.rb
+++ b/test/models/channel_test.rb
@@ -46,6 +46,21 @@ class ChannelTest < ActiveSupport::TestCase
     assert channel.save, "Failed to save channel without bandwidth"
   end
 
+  test "BANDWIDTHS constant should be defined" do
+    assert_equal [ "12.5 kHz", "20 kHz", "25 kHz" ], Channel::BANDWIDTHS
+  end
+
+  test "BANDWIDTHS constant should be frozen" do
+    assert Channel::BANDWIDTHS.frozen?
+  end
+
+  test "should save channel with valid bandwidth values" do
+    Channel::BANDWIDTHS.each do |bw|
+      channel = build(:channel, bandwidth: bw)
+      assert channel.save, "Failed to save channel with bandwidth: #{bw}"
+    end
+  end
+
   # Association Tests
   test "should belong to codeplug" do
     channel = build(:channel)

--- a/test/models/system_test.rb
+++ b/test/models/system_test.rb
@@ -151,14 +151,24 @@ class SystemTest < ActiveSupport::TestCase
   end
 
   # Bandwidth Tests
+  test "BANDWIDTHS constant should be defined" do
+    assert_equal [ "12.5 kHz", "20 kHz", "25 kHz" ], System::BANDWIDTHS
+  end
+
+  test "BANDWIDTHS constant should be frozen" do
+    assert System::BANDWIDTHS.frozen?
+  end
+
   test "should allow nil bandwidth" do
     system = build(:system, bandwidth: nil)
     assert system.save, "Failed to save system with nil bandwidth"
   end
 
-  test "should save system with bandwidth" do
-    system = build(:system, bandwidth: "25kHz")
-    assert system.save, "Failed to save system with bandwidth"
+  test "should save system with valid bandwidth values" do
+    System::BANDWIDTHS.each do |bw|
+      system = build(:system, bandwidth: bw)
+      assert system.save, "Failed to save system with bandwidth: #{bw}"
+    end
   end
 
   # Boolean Defaults Tests


### PR DESCRIPTION
## Summary
- Add `BANDWIDTHS` constant to System and Channel models with standardized values
- Replace free text bandwidth fields with dropdown select inputs
- Standard options: 12.5 kHz (narrow), 20 kHz (medium), 25 kHz (wide)

## Benefits
- Consistent data format across the application
- Prevents typos and invalid values
- Better user experience (no guessing format)
- Makes future filtering/searching by bandwidth easier

## Test Plan
- [x] Model tests for BANDWIDTHS constant (defined, frozen, valid values)
- [x] Controller test for bandwidth dropdown on System form
- [x] All 645 tests pass
- [x] RuboCop clean
- [x] Brakeman clean

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)