### PR TITLE
Hide talkgroup dropdown when analog system is selected

### DIFF
--- a/app/views/channels/_form.html.erb
+++ b/app/views/channels/_form.html.erb
@@ -1,3 +1,5 @@
+<% system_modes = @systems.each_with_object({}) { |s, h| h[s.id] = s.mode } %>
+
 <%= form_with model: [ @codeplug, channel ], local: true do |f| %>
   <% if channel.errors.any? %>
     <div class="alert alert-danger">
@@ -32,7 +34,7 @@
   </div>
 
   <h5 class="mt-4 mb-3">System Configuration</h5>
-  <div class="row">
+  <div class="row" id="system-configuration" data-system-modes="<%= system_modes.to_json %>">
     <div class="col-md-6 mb-3">
       <%= f.label :system_id, "System", class: "form-label" %>
       <%= f.collection_select :system_id, @systems, :id, :name,
@@ -41,7 +43,7 @@
       <div class="form-text">Select the system/repeater this channel uses</div>
     </div>
 
-    <div class="col-md-6 mb-3" id="talkgroup-field">
+    <div class="col-md-6 mb-3" id="talkgroup-field" style="display: <%= channel.system&.mode == 'analog' || channel.system.nil? ? 'none' : 'block' %>;">
       <%= f.label :system_talk_group_id, "Talkgroup (Digital Only)", class: "form-label" %>
       <%= f.collection_select :system_talk_group_id, @system_talk_groups, :id, ->(stg) { "#{stg.talk_group.name} (TS#{stg.timeslot || 'N/A'})" },
           { prompt: "Select a talkgroup", include_blank: true },
@@ -103,3 +105,40 @@
     <%= link_to "Cancel", channel.persisted? ? codeplug_channel_path(@codeplug, channel) : codeplug_channels_path(@codeplug), class: "btn btn-secondary" %>
   </div>
 <% end %>
+
+<script>
+  // Show/hide talkgroup field based on selected system's mode
+  document.addEventListener('turbo:load', function() {
+    const systemSelect = document.querySelector('#channel_system_id');
+    if (!systemSelect) return; // Exit if not on channel form
+
+    const talkgroupField = document.querySelector('#talkgroup-field');
+    const systemConfigEl = document.querySelector('#system-configuration');
+    if (!talkgroupField || !systemConfigEl) return;
+
+    const systemModes = JSON.parse(systemConfigEl.dataset.systemModes || '{}');
+
+    function updateTalkgroupVisibility() {
+      const selectedSystemId = systemSelect.value;
+
+      if (!selectedSystemId) {
+        // No system selected - hide talkgroup field
+        talkgroupField.style.display = 'none';
+        return;
+      }
+
+      const mode = systemModes[selectedSystemId];
+      if (mode === 'analog') {
+        talkgroupField.style.display = 'none';
+      } else {
+        talkgroupField.style.display = 'block';
+      }
+    }
+
+    // Run on page load
+    updateTalkgroupVisibility();
+
+    // Run when system dropdown changes
+    systemSelect.addEventListener('change', updateTalkgroupVisibility);
+  });
+</script>

--- a/test/system/channels_test.rb
+++ b/test/system/channels_test.rb
@@ -1,0 +1,78 @@
+require "application_system_test_case"
+
+class ChannelsTest < ApplicationSystemTestCase
+  setup do
+    @user = create(:user, email: "test@example.com", password: "password123")
+    @codeplug = create(:codeplug, user: @user, name: "Test Codeplug")
+  end
+
+  test "talkgroup field is hidden when analog system is selected" do
+    analog_system = create(:system, :analog, name: "Analog Repeater")
+    dmr_system = create(:system, name: "DMR Repeater", mode: "dmr", color_code: 1)
+
+    visit new_codeplug_channel_path(@codeplug)
+    fill_in "Email", with: "test@example.com"
+    fill_in "Password", with: "password123"
+    click_button "Log In"
+
+    # Initially, with no system selected, talkgroup field should be hidden
+    assert_selector "#talkgroup-field", visible: :hidden
+
+    # Select analog system - talkgroup field should remain hidden
+    select "Analog Repeater", from: "System"
+    assert_selector "#talkgroup-field", visible: :hidden
+
+    # Select DMR system - talkgroup field should become visible
+    select "DMR Repeater", from: "System"
+    assert_selector "#talkgroup-field", visible: :visible
+  end
+
+  test "talkgroup field is visible for digital systems on page load" do
+    dmr_system = create(:system, name: "DMR Repeater", mode: "dmr", color_code: 1)
+    channel = create(:channel, codeplug: @codeplug, system: dmr_system, name: "DMR Channel")
+
+    visit edit_codeplug_channel_path(@codeplug, channel)
+    fill_in "Email", with: "test@example.com"
+    fill_in "Password", with: "password123"
+    click_button "Log In"
+
+    # Talkgroup field should be visible for a channel with a digital system
+    assert_selector "#talkgroup-field", visible: :visible
+  end
+
+  test "talkgroup field is hidden for analog systems on page load" do
+    analog_system = create(:system, :analog, name: "Analog Repeater")
+    channel = create(:channel, codeplug: @codeplug, system: analog_system, name: "Analog Channel")
+
+    visit edit_codeplug_channel_path(@codeplug, channel)
+    fill_in "Email", with: "test@example.com"
+    fill_in "Password", with: "password123"
+    click_button "Log In"
+
+    # Talkgroup field should be hidden for a channel with an analog system
+    assert_selector "#talkgroup-field", visible: :hidden
+  end
+
+  test "talkgroup field visibility toggles when switching between analog and digital systems" do
+    analog_system = create(:system, :analog, name: "Analog Repeater")
+    p25_system = create(:system, :p25, name: "P25 System")
+    nxdn_system = create(:system, :nxdn, name: "NXDN System")
+
+    visit new_codeplug_channel_path(@codeplug)
+    fill_in "Email", with: "test@example.com"
+    fill_in "Password", with: "password123"
+    click_button "Log In"
+
+    # Select P25 system - talkgroup field should be visible
+    select "P25 System", from: "System"
+    assert_selector "#talkgroup-field", visible: :visible
+
+    # Switch to analog - talkgroup field should hide
+    select "Analog Repeater", from: "System"
+    assert_selector "#talkgroup-field", visible: :hidden
+
+    # Switch to NXDN - talkgroup field should be visible again
+    select "NXDN System", from: "System"
+    assert_selector "#talkgroup-field", visible: :visible
+  end
+end


### PR DESCRIPTION
## Summary
- Hide talkgroup dropdown on Channel form when an analog system is selected (talkgroups don't apply to analog)
- Show talkgroup dropdown for digital systems (DMR, P25, NXDN)
- Field visibility updates dynamically when system selection changes

## Implementation
- Added `data-system-modes` JSON attribute mapping system IDs to their modes
- Set initial field visibility based on channel's current system mode
- Added JavaScript to toggle visibility on system dropdown change

## Test plan
- [x] Verify talkgroup field hidden when no system selected
- [x] Verify talkgroup field hidden when analog system selected
- [x] Verify talkgroup field visible when DMR/P25/NXDN system selected
- [x] Verify field visibility toggles when switching systems
- [x] Verify correct visibility on edit form page load

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)