### PR TITLE
Fix drag and drop in codeplug layout creation

### DIFF
--- a/app/javascript/controllers/field_picker_controller.js
+++ b/app/javascript/controllers/field_picker_controller.js
@@ -222,7 +222,7 @@ export default class extends Controller {
         if (headerCounts[header] > 1) {
           field.classList.add("border-warning")
           const warning = document.createElement("span")
-          warning.className = "duplicate-warning badge bg-warning text-dark ms-2"
+          warning.className = "duplicate-warning badge bg-warning text-dark ms-2 me-2"
           warning.textContent = "Duplicate"
           headerInput.after(warning)
         }

--- a/app/views/codeplug_layouts/_form.html.erb
+++ b/app/views/codeplug_layouts/_form.html.erb
@@ -81,8 +81,8 @@
           </h6>
           <small class="text-muted">Drag to reorder</small>
         </div>
-        <div class="card-body">
-          <div class="layout-builder-container" style="min-height: 200px;">
+        <div class="card-body d-flex flex-column">
+          <div class="layout-builder-container flex-grow-1 d-flex flex-column">
             <div class="list-group" data-field-picker-target="layoutBuilder">
               <%# Layout fields will be rendered by JavaScript %>
             </div>
@@ -168,8 +168,9 @@
     max-width: 200px;
   }
 
-  /* Ensure the list-group has a minimum height for dropping even when empty */
+  /* Make the list-group fill the entire card body for easier dropping */
   .layout-builder-container .list-group {
+    flex: 1;
     min-height: 150px;
     border: 2px dashed #dee2e6;
     border-radius: 0.25rem;

--- a/app/views/codeplug_layouts/_form.html.erb
+++ b/app/views/codeplug_layouts/_form.html.erb
@@ -168,6 +168,33 @@
     max-width: 200px;
   }
 
+  /* Ensure the list-group has a minimum height for dropping even when empty */
+  .layout-builder-container .list-group {
+    min-height: 150px;
+    border: 2px dashed #dee2e6;
+    border-radius: 0.25rem;
+    padding: 0.5rem;
+    transition: border-color 0.2s, background-color 0.2s;
+  }
+
+  .layout-builder-container .list-group:empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Highlight the drop zone when dragging over it */
+  .layout-builder-container .list-group.sortable-ghost-class,
+  .layout-builder-container .list-group:has(.sortable-ghost) {
+    border-color: #0d6efd;
+    background-color: #f8f9ff;
+  }
+
+  .layout-builder-container .list-group:not(:empty) {
+    border-style: solid;
+    border-color: #dee2e6;
+  }
+
   .layout-builder-container .list-group:not(:empty) + .empty-message {
     display: none;
   }


### PR DESCRIPTION
## Summary
Fix the broken drag and drop functionality when creating a new codeplug layout. Users could drag fields from "Available Fields" but dropping them on the "CSV Columns" pane had no effect.

## Root Cause
When the CSV Columns list-group was empty, it had zero height, leaving no visible drop zone for users to drop fields onto. The `min-height: 200px` was on the parent container, but the actual drop target (the inner `list-group`) had no height.

## Changes
- Added `min-height: 150px` to the list-group to ensure a visible drop zone even when empty
- Added dashed border to visually indicate the drop area
- Added visual feedback (blue border, light blue background) when dragging over the drop zone
- Border becomes solid when items are present

## Test plan
- [x] All unit tests pass (666 runs, 0 failures)
- [x] Rubocop passes with no offenses
- [x] Brakeman security scan passes with no warnings
- [ ] Manually test: Navigate to new codeplug layout
- [ ] Manually test: Drag a field from Available Fields
- [ ] Manually test: Drop on CSV Columns pane - field should be added
- [ ] Manually test: Reorder fields within CSV Columns
- [ ] Manually test: Remove a field from CSV Columns

Fixes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)